### PR TITLE
Added option to remove informational print statements

### DIFF
--- a/ruuvitag_sensor/ble_communication.py
+++ b/ruuvitag_sensor/ble_communication.py
@@ -47,8 +47,9 @@ class BleCommunicationNix(BleCommunication):
     '''Bluetooth LE communication for Linux'''
 
     @staticmethod
-    def start():
-        print('Start receiving broadcasts')
+    def start(verbose=True):
+        if verbose:
+            print('Start receiving broadcasts')
         DEVNULL = subprocess.DEVNULL if sys.version_info >= (3, 3) else open(os.devnull, 'wb')
 
         subprocess.call('sudo hciconfig hci0 reset', shell=True, stdout=DEVNULL)
@@ -57,11 +58,12 @@ class BleCommunicationNix(BleCommunication):
         return (hcitool, hcidump)
 
     @staticmethod
-    def stop(hcitool, hcidump):
+    def stop(hcitool, hcidump, verbose=True):
         # import psutil here so as long as all implementations are in the same file, all will work
         import psutil
 
-        print('Stop receiving broadcasts')
+        if verbose:
+            print('Stop receiving broadcasts')
 
         def kill_child_processes(parent_pid):
             try:
@@ -118,12 +120,13 @@ class BleCommunicationNix(BleCommunication):
         BleCommunicationNix.stop(procs[0], procs[1])
 
     @staticmethod
-    def get_data(mac):
+    def get_data(mac, verbose=True):
         data = None
         data_iter = BleCommunicationNix.get_datas()
         for data in data_iter:
             if mac == data[0]:
-                print('Data found')
+                if verbose:
+                    print('Data found')
                 data_iter.send(StopIteration)
                 data = data[1]
                 break

--- a/ruuvitag_sensor/ruuvi.py
+++ b/ruuvitag_sensor/ruuvi.py
@@ -49,8 +49,8 @@ class RuuviTagSensor(object):
         return self._state
 
     @staticmethod
-    def get_data(mac):
-        raw = ble.get_data(mac)
+    def get_data(mac, verbose=True):
+        raw = ble.get_data(mac, verbose)
         return RuuviTagSensor.convert_data(raw)
 
     @staticmethod
@@ -75,7 +75,7 @@ class RuuviTagSensor(object):
         return (None, None)
 
     @staticmethod
-    def find_ruuvitags():
+    def find_ruuvitags(verbose=True):
         """
         Find all RuuviTags. Function will print the mac and the state of the sensors when found.
         Function will execute as long as it is stopped. Stop ecexution with Crtl+C.
@@ -83,12 +83,13 @@ class RuuviTagSensor(object):
         Returns:
             dict: MAC and state of found sensors
         """
-
-        print('Finding RuuviTags. Stop with Ctrl+C.')
+        
+        if verbose:
+            print('Finding RuuviTags. Stop with Ctrl+C.')
 
         datas = dict()
 
-        for new_data in RuuviTagSensor._get_ruuvitag_datas():
+        for new_data in RuuviTagSensor._get_ruuvitag_datas(verbose=verbose):
             if new_data[0] in datas:
                 continue
             datas[new_data[0]] = new_data[1]
@@ -98,9 +99,9 @@ class RuuviTagSensor(object):
         return datas
 
     @staticmethod
-    def get_data_for_sensors(macs=[], search_duratio_sec=5):
+    def get_data_for_sensors(macs=[], search_duratio_sec=5, verbose=True):
         """
-        Get lates data for sensors in the MAC's list.
+        Get latest data for sensors in the MAC's list.
 
         Args:
             macs (array): MAC addresses
@@ -109,19 +110,20 @@ class RuuviTagSensor(object):
             dict: MAC and state of found sensors
         """
 
-        print('Get latest data for sensors. Stop with Ctrl+C.')
-        print('Stops automatically in {}s'.format(search_duratio_sec))
-        print('MACs: {}'.format(macs))
+        if verbose:
+            print('Get latest data for sensors. Stop with Ctrl+C.')
+            print('Stops automatically in {}s'.format(search_duratio_sec))
+            print('MACs: {}'.format(macs))
 
         datas = dict()
 
-        for new_data in RuuviTagSensor._get_ruuvitag_datas(macs, search_duratio_sec):
+        for new_data in RuuviTagSensor._get_ruuvitag_datas(macs, search_duratio_sec, verbose=verbose):
             datas[new_data[0]] = new_data[1]
 
         return datas
 
     @staticmethod
-    def get_datas(callback, macs=[], run_flag=RunFlag()):
+    def get_datas(callback, macs=[], run_flag=RunFlag(), verbose=True):
         """
         Get data for all ruuvitag sensors or sensors in the MAC's list.
 
@@ -131,8 +133,9 @@ class RuuviTagSensor(object):
             run_flag (object): RunFlag object. Function executes while run_flag.running
         """
 
-        print('Get latest data for sensors. Stop with Ctrl+C.')
-        print('MACs: {}'.format(macs))
+        if verbose:
+            print('Get latest data for sensors. Stop with Ctrl+C.')
+            print('MACs: {}'.format(macs))
 
         for new_data in RuuviTagSensor._get_ruuvitag_datas(macs, None, run_flag):
             callback(new_data)
@@ -160,7 +163,7 @@ class RuuviTagSensor(object):
         return self._state
 
     @staticmethod
-    def _get_ruuvitag_datas(macs=[], search_duratio_sec=None, run_flag=RunFlag()):
+    def _get_ruuvitag_datas(macs=[], search_duratio_sec=None, run_flag=RunFlag(), verbose=True):
         """
         Get data from BluetoothCommunication and handle data encoding.
 
@@ -174,7 +177,7 @@ class RuuviTagSensor(object):
         """
 
         start_time = time.time()
-        data_iter = ble.get_datas()
+        data_iter = ble.get_datas(verbose)
 
         for ble_data in data_iter:
             # Check duration


### PR DESCRIPTION
When using the library programmatically, informational print statements are unnecessary. This is a quick parameter-driven fix, alternative would be to ise logging. 

This is as yet poorly tested. 

Also - thanks for excellent installation instructions!