### PR TITLE
Circumvented pipe buffering to assure all readings are propagated timely

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(name='ruuvitag_sensor',
           'rx',
           'psutil;platform_system=="Linux"',
           'futures;python_version<"3.3"',
+          'ptyprocess'
       ],
       license='MIT',
       packages=['ruuvitag_sensor'],

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name='ruuvitag_sensor',
           'rx',
           'psutil;platform_system=="Linux"',
           'futures;python_version<"3.3"',
-          'ptyprocess'
+          'ptyprocess;platform_system=="Linux"'
       ],
       license='MIT',
       packages=['ruuvitag_sensor'],


### PR DESCRIPTION
Piping the hcidump output triggers pipe buffering (4 KiB by default). As
a single RuuviTag data point is just a few bytes long, it can take a long time
(minutes in my case) for the buffer to fill up in environments with low
Bluetooth traffic.

This pull request works around that by using a pty terminal instead of a pipe,
which doesn't trigger the buffering logic on hcidump, hence all updates get
propagated to consumers immediately.