### PR TITLE
Fix #40 : Ruuvi FW 1.2.8 not being received

### DIFF
--- a/ruuvitag_sensor/ruuvi.py
+++ b/ruuvitag_sensor/ruuvi.py
@@ -202,13 +202,12 @@ class RuuviTagSensor(object):
         Returns:
             string: Sensor data
         """
+        # Search of FF990403 (Manufacturer Specific Data (FF) / Ruuvi Innovations ltd (9904) / Format 3 (03))
         try:
-            if len(raw) != 54:
+            if "FF990403" not in raw:
                 return None
 
-            if raw[16:18] != '03':
-                return None
-
-            return raw[16:]
+            payload_start = raw.index("FF990403") + 6;
+            return raw[payload_start:]
         except:
             return None

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -51,6 +51,16 @@ class TestDecoder(TestCase):
         self.assertNotEqual(data['acceleration_y'], 0)
         self.assertNotEqual(data['acceleration_z'], 0)
 
+        data = decoder.decode_data('03291A1ECE1EFC18F94202CA0B53BB')
+        self.assertEqual(data['temperature'], 26.3)
+        self.assertEqual(data['pressure'], 1027.66)
+        self.assertEqual(data['humidity'], 20.5)
+        self.assertEqual(data['battery'], 2899)
+        self.assertNotEqual(data['acceleration'], 0)
+        self.assertEqual(data['acceleration_x'], -1000)
+        self.assertNotEqual(data['acceleration_y'], 0)
+        self.assertNotEqual(data['acceleration_z'], 0)
+
     def test_df3decode_is_valid_max_values(self):
         decoder = Df3Decoder()
         humidity = 'C8'

--- a/tests/test_ruuvitag_sensor.py
+++ b/tests/test_ruuvitag_sensor.py
@@ -47,7 +47,8 @@ class TestRuuviTagSensor(TestCase):
             ('CC:2C:6A:1E:59:3D', '1E0201060303AAFE1616AAFE10EE037275752E76692F23416A7759414D4663CD'),
             ('DD:2C:6A:1E:59:3D', '1E0201060303AAFE1616AAFE10EE037275752E76692F23416A7759414D4663CD'),
             ('EE:2C:6A:1E:59:3D', '1F0201060303AAFE1716AAFE10F9037275752E76692F23416A5558314D417730C3'),
-            ('FF:2C:6A:1E:59:3D', '1902010415FF990403291A1ECE1E02DEF94202CA0B5300000000BB')
+            ('FF:2C:6A:1E:59:3D', '1902010415FF990403291A1ECE1E02DEF94202CA0B5300000000BB'),
+            ('00:2C:6A:1E:59:3D', '1902010415FF990403291A1ECE1E02DEF94202CA0B53BB')
         ]
 
         for data in datas:
@@ -59,7 +60,7 @@ class TestRuuviTagSensor(TestCase):
            get_datas)
     def test_find_tags(self):
         tags = RuuviTagSensor.find_ruuvitags()
-        self.assertEqual(5, len(tags))
+        self.assertEqual(6, len(tags))
 
     @patch('ruuvitag_sensor.ble_communication.BleCommunicationDummy.get_datas',
            get_datas)
@@ -87,7 +88,7 @@ class TestRuuviTagSensor(TestCase):
     def test_get_datas(self):
         datas = []
         RuuviTagSensor.get_datas(lambda x: datas.append(x))
-        self.assertEqual(5, len(datas))
+        self.assertEqual(6, len(datas))
 
     @patch('ruuvitag_sensor.ble_communication.BleCommunicationDummy.get_datas',
            get_datas)


### PR DESCRIPTION
Adds test cases with data format 3 without trailing nulls and modifies parser to search for "FF990403" in the data. 

Tests pass and Raspberry Pi 3 can receive data from RuuviTag running 1.2.8