### PR TITLE
Implement 30

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,10 @@ Example data has data from 4 sensors with different firmwares.
 
 ```python
 {
-'CA:F7:44:DE:EB:E1': { 'data_format': 2, 'temperature': 22.0, 'humidity': 28.0, 'pressure': 991.0, 'identifier': None }, 
-'F4:A5:74:89:16:57': { 'data_format': 4, 'temperature': 23.24, 'humidity': 29.0, 'pressure': 991.0, 'identifier': '0' },
-'A3:GE:2D:91:A4:1F': { 'data_format': 3, 'battery': 2899, 'pressure': 1027.66, 'humidity': 20.5, 'acceleration': 63818.215675463696, 'acceleration_x': 200.34, 'acceleration_y': 0.512, 'acceleration_z': -200.42, 'temperature': 26.3},
-'CB:B8:33:4C:88:4F': { 'data_format': 5, 'battery': 2.995, 'pressure': 1000.43, 'mac': 'cbb8334c884f', 'measurement_sequence_number': 2467, 'acceleration_z': 1028, 'acceleration': 1028.0389097694697, 'temperature': 22.14, 'acceleration_y': -8, 'acceleration_x': 4, 'humidity': 53.97, 'tx_power': 4, 'movement_counter': 70 }
+'CA:F7:44:DE:EB:E1': { 'data_format': 2, 'temperature': 22.0, 'humidity': 28.0, 'pressure': 991.0, 'identifier': None, 'rssi': None }, 
+'F4:A5:74:89:16:57': { 'data_format': 4, 'temperature': 23.24, 'humidity': 29.0, 'pressure': 991.0, 'identifier': '0', 'rssi': None },
+'A3:GE:2D:91:A4:1F': { 'data_format': 3, 'battery': 2899, 'pressure': 1027.66, 'humidity': 20.5, 'acceleration': 63818.215675463696, 'acceleration_x': 200.34, 'acceleration_y': 0.512, 'acceleration_z': -200.42, 'temperature': 26.3, 'rssi': None },
+'CB:B8:33:4C:88:4F': { 'data_format': 5, 'battery': 2.995, 'pressure': 1000.43, 'mac': 'cbb8334c884f', 'measurement_sequence_number': 2467, 'acceleration_z': 1028, 'acceleration': 1028.0389097694697, 'temperature': 22.14, 'acceleration_y': -8, 'acceleration_x': 4, 'humidity': 53.97, 'tx_power': 4, 'movement_counter': 70, 'rssi': None }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -210,10 +210,10 @@ Example data has data from 4 sensors with different firmwares.
 
 ```python
 {
-'CA:F7:44:DE:EB:E1': { 'temperature': 22.0, 'humidity': 28.0, 'pressure': 991.0, 'identifier': None }, 
-'F4:A5:74:89:16:57': { 'temperature': 23.24, 'humidity': 29.0, 'pressure': 991.0, 'identifier': '0' },
-'A3:GE:2D:91:A4:1F': { 'battery': 2899, 'pressure': 1027.66, 'humidity': 20.5, 'acceleration': 63818.215675463696, 'acceleration_x': 200.34, 'acceleration_y': 0.512, 'acceleration_z': -200.42, 'temperature': 26.3},
-'CB:B8:33:4C:88:4F': {'battery': 2.995, 'pressure': 1000.43, 'mac': 'cbb8334c884f', 'measurement_sequence_number': 2467, 'acceleration_z': 1028, 'acceleration': 1028.0389097694697, 'temperature': 22.14, 'acceleration_y': -8, 'acceleration_x': 4, 'humidity': 53.97, 'tx_power': 4, 'movement_counter': 70}
+'CA:F7:44:DE:EB:E1': { 'data_format': 2, 'temperature': 22.0, 'humidity': 28.0, 'pressure': 991.0, 'identifier': None }, 
+'F4:A5:74:89:16:57': { 'data_format': 4, 'temperature': 23.24, 'humidity': 29.0, 'pressure': 991.0, 'identifier': '0' },
+'A3:GE:2D:91:A4:1F': { 'data_format': 3, 'battery': 2899, 'pressure': 1027.66, 'humidity': 20.5, 'acceleration': 63818.215675463696, 'acceleration_x': 200.34, 'acceleration_y': 0.512, 'acceleration_z': -200.42, 'temperature': 26.3},
+'CB:B8:33:4C:88:4F': { 'data_format': 5, 'battery': 2.995, 'pressure': 1000.43, 'mac': 'cbb8334c884f', 'measurement_sequence_number': 2467, 'acceleration_z': 1028, 'acceleration': 1028.0389097694697, 'temperature': 22.14, 'acceleration_y': -8, 'acceleration_x': 4, 'humidity': 53.97, 'tx_power': 4, 'movement_counter': 70 }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ $ ./verification.sh
 Examples are in [examples](https://github.com/ttu/ruuvitag-sensor/tree/master/examples) directory, e.g.
 
 * Keep track of each sensors current status and send updated data to server. [Sync](https://github.com/ttu/ruuvitag-sensor/blob/master/examples/send_updated_sync.py) and [async](https://github.com/ttu/ruuvitag-sensor/blob/master/examples/send_updated_async.py) version.
-* Send found sensor data to InfluxDB. [Reactive](https://github.com/ttu/ruuvitag-sensor/blob/master/examples/post_to_influxdb_rx.py) and [non-reactive](https://github.com/ttu/ruuvitag-sensor/blob/master/examples/post_to_influxdb.py) version.
+* Send found sensor data to InfluxDB. [Reactive](https://github.com/ttu/ruuvitag-sensor/blob/master/examples/post_to_influxdb_rx.py) and [non-reactive](https://github.com/ttu/ruuvitag-sensor/blob/master/examples/post_to_influxdb.py) version. Naming convention of sent data matches [RuuviCollector library](https://github.com/scrin/ruuvicollector).
 * Simple HTTP Server for serving found sensor data. [Flask](https://github.com/ttu/ruuvitag-sensor/blob/master/examples/http_server.py), [aiohttp](https://github.com/ttu/ruuvitag-sensor/blob/master/examples/http_server_asyncio.py) and [aiohttp with Rx](https://github.com/ttu/ruuvitag-sensor/blob/master/examples/http_server_asyncio_rx.py).
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -210,10 +210,10 @@ Example data has data from 4 sensors with different firmwares.
 
 ```python
 {
-'CA:F7:44:DE:EB:E1': { 'data_format': 2, 'temperature': 22.0, 'humidity': 28.0, 'pressure': 991.0, 'identifier': None, 'rssi': None }, 
-'F4:A5:74:89:16:57': { 'data_format': 4, 'temperature': 23.24, 'humidity': 29.0, 'pressure': 991.0, 'identifier': '0', 'rssi': None },
-'A3:GE:2D:91:A4:1F': { 'data_format': 3, 'battery': 2899, 'pressure': 1027.66, 'humidity': 20.5, 'acceleration': 63818.215675463696, 'acceleration_x': 200.34, 'acceleration_y': 0.512, 'acceleration_z': -200.42, 'temperature': 26.3, 'rssi': None },
-'CB:B8:33:4C:88:4F': { 'data_format': 5, 'battery': 2.995, 'pressure': 1000.43, 'mac': 'cbb8334c884f', 'measurement_sequence_number': 2467, 'acceleration_z': 1028, 'acceleration': 1028.0389097694697, 'temperature': 22.14, 'acceleration_y': -8, 'acceleration_x': 4, 'humidity': 53.97, 'tx_power': 4, 'movement_counter': 70, 'rssi': None }
+'CA:F7:44:DE:EB:E1': { 'data_format': 2, 'temperature': 22.0, 'humidity': 28.0, 'pressure': 991.0, 'identifier': None }, 
+'F4:A5:74:89:16:57': { 'data_format': 4, 'temperature': 23.24, 'humidity': 29.0, 'pressure': 991.0, 'identifier': '0' },
+'A3:GE:2D:91:A4:1F': { 'data_format': 3, 'battery': 2899, 'pressure': 1027.66, 'humidity': 20.5, 'acceleration': 63818.215675463696, 'acceleration_x': 200.34, 'acceleration_y': 0.512, 'acceleration_z': -200.42, 'temperature': 26.3},
+'CB:B8:33:4C:88:4F': { 'data_format': 5, 'battery': 2.995, 'pressure': 1000.43, 'mac': 'cbb8334c884f', 'measurement_sequence_number': 2467, 'acceleration_z': 1028, 'acceleration': 1028.0389097694697, 'temperature': 22.14, 'acceleration_y': -8, 'acceleration_x': 4, 'humidity': 53.97, 'tx_power': 4, 'movement_counter': 70 }
 }
 ```
 

--- a/examples/post_to_influxdb.py
+++ b/examples/post_to_influxdb.py
@@ -39,6 +39,7 @@ def convert_to_influx(mac, payload):
     returns:
         Object to be written to InfluxDB
     '''
+    dataFormat = payload["data_format"] if ('data_format' in payload) else None
     fields = {}
     fields["temperature"]               = payload["temperature"] if ('temperature' in payload) else None
     fields["humidity"]                  = payload["humidity"] if ('humidity' in payload) else None
@@ -47,15 +48,16 @@ def convert_to_influx(mac, payload):
     fields["accelerationY"]             = payload["acceleration_y"] if ('acceleration_y' in payload) else None
     fields["accelerationZ"]             = payload["acceleration_z"] if ('acceleration_z' in payload) else None
     fields["batteryVoltage"]            = payload["battery"]/1000.0 if hasattr(payload, 'battery') else None
-    fields["dataFormat"]                = payload["data_format"] if ('data_format' in payload) else None
     fields["txPower"]                   = payload["tx_power"] if ('tx_power' in payload) else None
     fields["movementCounter"]           = payload["battery"] if ('battery' in payload) else None
     fields["measurementSequenceNumber"] = payload["measurement_sequence_number"] if ('measurement_sequence_number' in payload) else None
     fields["tagID"]                     = payload["tagID"] if ('tagID' in payload) else None
+    fields["rssi"]                      = received_data[1]["rssi"] if ('rssi' in received_data[1]) else None
     return {
         "measurement": "ruuvi_measurements",
         "tags": {
-            "mac": mac
+            "mac": mac,
+            "dataFormat": dataFormat
         },
         "fields": fields
     }

--- a/examples/post_to_influxdb.py
+++ b/examples/post_to_influxdb.py
@@ -49,8 +49,7 @@ def convert_to_influx(mac, payload):
     return {
         "measurement": "ruuvitag",
         "tags": {
-            "mac": mac,
-            "gateway_id": "ruuvitag-sensor"
+            "mac": mac
         },
         "fields": fields
     }

--- a/examples/post_to_influxdb.py
+++ b/examples/post_to_influxdb.py
@@ -33,6 +33,12 @@ from ruuvitag_sensor.ruuvi import RuuviTagSensor
 
 
 def convert_to_influx(mac, payload):
+    '''
+    Convert data into RuuviCollecor naming schme and scale
+
+    returns:
+        Object to be written to InfluxDB
+    '''
     fields = {}
     fields["temperature"]               = payload["temperature"] if ('temperature' in payload) else None
     fields["humidity"]                  = payload["humidity"] if ('humidity' in payload) else None
@@ -40,14 +46,14 @@ def convert_to_influx(mac, payload):
     fields["accelerationX"]             = payload["acceleration_x"] if ('acceleration_x' in payload) else None
     fields["accelerationY"]             = payload["acceleration_y"] if ('acceleration_y' in payload) else None
     fields["accelerationZ"]             = payload["acceleration_z"] if ('acceleration_z' in payload) else None
-    fields["batteryVoltage"]            = payload["battery"] if hasattr(payload, 'battery') else None
+    fields["batteryVoltage"]            = payload["battery"]/1000.0 if hasattr(payload, 'battery') else None
     fields["dataFormat"]                = payload["data_format"] if ('data_format' in payload) else None
     fields["txPower"]                   = payload["tx_power"] if ('tx_power' in payload) else None
     fields["movementCounter"]           = payload["battery"] if ('battery' in payload) else None
     fields["measurementSequenceNumber"] = payload["measurement_sequence_number"] if ('measurement_sequence_number' in payload) else None
     fields["tagID"]                     = payload["tagID"] if ('tagID' in payload) else None
     return {
-        "measurement": "ruuvitag",
+        "measurement": "ruuvi_measurements",
         "tags": {
             "mac": mac
         },
@@ -55,7 +61,7 @@ def convert_to_influx(mac, payload):
     }
 
 
-client = InfluxDBClient(host="localhost", port=8086, database="tag_data")
+client = InfluxDBClient(host="localhost", port=8086, database="ruuvi")
 
 while True:
     datas = RuuviTagSensor.get_data_for_sensors()

--- a/examples/post_to_influxdb.py
+++ b/examples/post_to_influxdb.py
@@ -33,16 +33,26 @@ from ruuvitag_sensor.ruuvi import RuuviTagSensor
 
 
 def convert_to_influx(mac, payload):
+    fields = {}
+    fields["temperature"]               = payload["temperature"] if ('temperature' in payload) else None
+    fields["humidity"]                  = payload["humidity"] if ('humidity' in payload) else None
+    fields["pressure"]                  = payload["pressure"] if ('pressure' in payload) else None
+    fields["accelerationX"]             = payload["acceleration_x"] if ('acceleration_x' in payload) else None
+    fields["accelerationY"]             = payload["acceleration_y"] if ('acceleration_y' in payload) else None
+    fields["accelerationZ"]             = payload["acceleration_z"] if ('acceleration_z' in payload) else None
+    fields["batteryVoltage"]            = payload["battery"] if hasattr(payload, 'battery') else None
+    fields["dataFormat"]                = payload["data_format"] if ('data_format' in payload) else None
+    fields["txPower"]                   = payload["tx_power"] if ('tx_power' in payload) else None
+    fields["movementCounter"]           = payload["battery"] if ('battery' in payload) else None
+    fields["measurementSequenceNumber"] = payload["measurement_sequence_number"] if ('measurement_sequence_number' in payload) else None
+    fields["tagID"]                     = payload["tagID"] if ('tagID' in payload) else None
     return {
         "measurement": "ruuvitag",
         "tags": {
-            "mac": mac
+            "mac": mac,
+            "gateway_id": "ruuvitag-sensor"
         },
-        "fields": {
-            "temperature": payload["temperature"],
-            "humidity": payload["humidity"],
-            "pressure": payload["pressure"]
-        }
+        "fields": fields
     }
 
 

--- a/examples/post_to_influxdb_rx.py
+++ b/examples/post_to_influxdb_rx.py
@@ -7,24 +7,33 @@ Check guide and requirements from post_to_influxdb.py
 from influxdb import InfluxDBClient
 from ruuvitag_sensor.ruuvi_rx import RuuviTagReactive
 
-client = InfluxDBClient(host="localhost", port=8086, database="tag_data")
+client = InfluxDBClient(host="playground.ruuvi.com", port=8086, database="ruuvi")
 
 
 def write_to_influxdb(received_data):
+    fields = {}
+    fields["temperature"]               = received_data[1]["temperature"] if ('temperature' in received_data[1]) else None
+    fields["humidity"]                  = received_data[1]["humidity"] if ('humidity' in received_data[1]) else None
+    fields["pressure"]                  = received_data[1]["pressure"] if ('pressure' in received_data[1]) else None
+    fields["accelerationX"]             = received_data[1]["acceleration_x"] if ('acceleration_x' in received_data[1]) else None
+    fields["accelerationY"]             = received_data[1]["acceleration_y"] if ('acceleration_y' in received_data[1]) else None
+    fields["accelerationZ"]             = received_data[1]["acceleration_z"] if ('acceleration_z' in received_data[1]) else None
+    fields["batteryVoltage"]            = received_data[1]["battery"] if hasattr(received_data[1], 'battery') else None
+    fields["dataFormat"]                = received_data[1]["data_format"] if ('data_format' in received_data[1]) else None
+    fields["txPower"]                   = received_data[1]["tx_power"] if ('tx_power' in received_data[1]) else None
+    fields["movementCounter"]           = received_data[1]["battery"] if ('battery' in received_data[1]) else None
+    fields["measurementSequenceNumber"] = received_data[1]["measurement_sequence_number"] if ('measurement_sequence_number' in received_data[1]) else None
+    fields["tagID"]                     = received_data[1]["tagID"] if ('tagID' in received_data[1]) else None
     json_body = [
         {
-            "measurement": "ruuvitag",
+            "measurement": "ruuvi_measurements",
             "tags": {
-                "mac": received_data[0]
+                "mac": received_data[0],
+                "gateway_id": "ruuvitag-sensor-rx"
             },
-            "fields": {
-                "temperature": received_data[1]["temperature"],
-                "humidity": received_data[1]["humidity"],
-                "pressure": received_data[1]["pressure"]
-            }
+            "fields": fields
         }
     ]
-
     client.write_points(json_body)
 
 

--- a/examples/post_to_influxdb_rx.py
+++ b/examples/post_to_influxdb_rx.py
@@ -14,6 +14,7 @@ def write_to_influxdb(received_data):
     '''
     Convert data into RuuviCollecor naming schme and scale
     '''
+    dataFormat = received_data[1]["data_format"] if ('data_format' in received_data[1]) else None
     fields = {}
     fields["temperature"]               = received_data[1]["temperature"] if ('temperature' in received_data[1]) else None
     fields["humidity"]                  = received_data[1]["humidity"] if ('humidity' in received_data[1]) else None
@@ -22,16 +23,17 @@ def write_to_influxdb(received_data):
     fields["accelerationY"]             = received_data[1]["acceleration_y"] if ('acceleration_y' in received_data[1]) else None
     fields["accelerationZ"]             = received_data[1]["acceleration_z"] if ('acceleration_z' in received_data[1]) else None
     fields["batteryVoltage"]            = received_data[1]["battery"]/1000.0 if hasattr(received_data[1], 'battery') else None
-    fields["dataFormat"]                = received_data[1]["data_format"] if ('data_format' in received_data[1]) else None
     fields["txPower"]                   = received_data[1]["tx_power"] if ('tx_power' in received_data[1]) else None
     fields["movementCounter"]           = received_data[1]["battery"] if ('battery' in received_data[1]) else None
     fields["measurementSequenceNumber"] = received_data[1]["measurement_sequence_number"] if ('measurement_sequence_number' in received_data[1]) else None
     fields["tagID"]                     = received_data[1]["tagID"] if ('tagID' in received_data[1]) else None
+    fields["rssi"]                      = received_data[1]["rssi"] if ('rssi' in received_data[1]) else None
     json_body = [
         {
             "measurement": "ruuvi_measurements",
             "tags": {
-                "mac": received_data[0]
+                "mac": received_data[0],
+                "dataFormat": dataFormat
             },
             "fields": fields
         }

--- a/examples/post_to_influxdb_rx.py
+++ b/examples/post_to_influxdb_rx.py
@@ -7,7 +7,7 @@ Check guide and requirements from post_to_influxdb.py
 from influxdb import InfluxDBClient
 from ruuvitag_sensor.ruuvi_rx import RuuviTagReactive
 
-client = InfluxDBClient(host="playground.ruuvi.com", port=8086, database="ruuvi")
+client = InfluxDBClient(host="localhost", port=8086, database="tag_data")
 
 
 def write_to_influxdb(received_data):
@@ -26,10 +26,9 @@ def write_to_influxdb(received_data):
     fields["tagID"]                     = received_data[1]["tagID"] if ('tagID' in received_data[1]) else None
     json_body = [
         {
-            "measurement": "ruuvi_measurements",
+            "measurement": "ruuvitag",
             "tags": {
-                "mac": received_data[0],
-                "gateway_id": "ruuvitag-sensor-rx"
+                "mac": received_data[0]
             },
             "fields": fields
         }

--- a/examples/post_to_influxdb_rx.py
+++ b/examples/post_to_influxdb_rx.py
@@ -7,10 +7,13 @@ Check guide and requirements from post_to_influxdb.py
 from influxdb import InfluxDBClient
 from ruuvitag_sensor.ruuvi_rx import RuuviTagReactive
 
-client = InfluxDBClient(host="localhost", port=8086, database="tag_data")
+client = InfluxDBClient(host="localhost", port=8086, database="ruuvitag")
 
 
 def write_to_influxdb(received_data):
+    '''
+    Convert data into RuuviCollecor naming schme and scale
+    '''
     fields = {}
     fields["temperature"]               = received_data[1]["temperature"] if ('temperature' in received_data[1]) else None
     fields["humidity"]                  = received_data[1]["humidity"] if ('humidity' in received_data[1]) else None
@@ -18,7 +21,7 @@ def write_to_influxdb(received_data):
     fields["accelerationX"]             = received_data[1]["acceleration_x"] if ('acceleration_x' in received_data[1]) else None
     fields["accelerationY"]             = received_data[1]["acceleration_y"] if ('acceleration_y' in received_data[1]) else None
     fields["accelerationZ"]             = received_data[1]["acceleration_z"] if ('acceleration_z' in received_data[1]) else None
-    fields["batteryVoltage"]            = received_data[1]["battery"] if hasattr(received_data[1], 'battery') else None
+    fields["batteryVoltage"]            = received_data[1]["battery"]/1000.0 if hasattr(received_data[1], 'battery') else None
     fields["dataFormat"]                = received_data[1]["data_format"] if ('data_format' in received_data[1]) else None
     fields["txPower"]                   = received_data[1]["tx_power"] if ('tx_power' in received_data[1]) else None
     fields["movementCounter"]           = received_data[1]["battery"] if ('battery' in received_data[1]) else None
@@ -26,7 +29,7 @@ def write_to_influxdb(received_data):
     fields["tagID"]                     = received_data[1]["tagID"] if ('tagID' in received_data[1]) else None
     json_body = [
         {
-            "measurement": "ruuvitag",
+            "measurement": "ruuvi_measurements",
             "tags": {
                 "mac": received_data[0]
             },

--- a/ruuvitag_sensor/decoder.py
+++ b/ruuvitag_sensor/decoder.py
@@ -16,10 +16,13 @@ def get_decoder(data_type):
     '''
     if data_type == 2:
         return UrlDecoder()
+    elif data_type == 4:
+        return UrlDecoder()
     elif data_type == 3:
         return Df3Decoder()
     else:
         return Df5Decoder()
+
 
 def twos_complement(value, bits):
     if (value & (1 << (bits - 1))) != 0:
@@ -45,7 +48,7 @@ class UrlDecoder(object):
     Decoder operations are ported from:
     https://github.com/ruuvi/sensor-protocol-for-eddystone-url/blob/master/index.html
 
-    0:   uint8_t     format;          // (0x01 = realtime sensor readings)
+    0:   uint8_t     format;          // (0x02 = realtime sensor readings)
     1:   uint8_t     humidity;        // one lsb is 0.5%
     2-3: uint16_t    temperature;     // Signed 8.8 fixed-point notation.
     4-5: uint16_t    pressure;        // (-50kPa)
@@ -80,11 +83,14 @@ class UrlDecoder(object):
         '''
         try:
             identifier = None
+            data_format = 2
             if len(encoded) > 8:
+                data_format = 4
                 identifier = encoded[8:]
                 encoded = encoded[:8]
             decoded = bytearray(base64.b64decode(encoded, '-_'))
             return {
+                'data_format': data_format,
                 'temperature': self._get_temperature(decoded),
                 'humidity': self._get_humidity(decoded),
                 'pressure': self._get_pressure(decoded),
@@ -141,6 +147,7 @@ class Df3Decoder(object):
             byte_data = bytearray.fromhex(data)
             acc_x, acc_y, acc_z = self._get_acceleration(byte_data)
             return {
+                'data_format': 3,
                 'humidity': self._get_humidity(byte_data),
                 'temperature': self._get_temperature(byte_data),
                 'pressure': self._get_pressure(byte_data),
@@ -241,6 +248,7 @@ class Df5Decoder(object):
             byte_data = bytearray.fromhex(data)
             acc_x, acc_y, acc_z = self._get_acceleration(byte_data)
             return {
+                'data_format': 5,
                 'humidity': self._get_humidity(byte_data),
                 'temperature': self._get_temperature(byte_data),
                 'pressure': self._get_pressure(byte_data),

--- a/ruuvitag_sensor/decoder.py
+++ b/ruuvitag_sensor/decoder.py
@@ -207,7 +207,7 @@ class Df5Decoder(object):
     def _get_powerinfo(self, data):
         '''Return battery voltage and tx power '''
         power_info = (data[13] & 0xFF) << 8 | (data[14] & 0xFF)
-        battery_voltage = rshift(power_info, 5) / 1000 + 1.6
+        battery_voltage = rshift(power_info, 5) + 1600
         tx_power = (power_info & 0b11111) * 2 - 40
 
         if rshift(power_info, 5) == 0b11111111111:

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -126,7 +126,7 @@ class TestDecoder(TestCase):
         self.assertEqual(data['acceleration_y'], -4)
         self.assertEqual(data['acceleration_z'], 1036)
         self.assertEqual(data['tx_power'], 4)
-        self.assertEqual(data['battery'], 2.977)
+        self.assertEqual(data['battery'], 2977)
         self.assertEqual(data['movement_counter'], 66)
         self.assertEqual(data['measurement_sequence_number'], 205)
         self.assertEqual(data['mac'], 'cbb8334c884f')

--- a/tests/test_ruuvitag_sensor.py
+++ b/tests/test_ruuvitag_sensor.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from unittest.mock import patch
+from mock import patch, MagicMock
 
 from ruuvitag_sensor.ruuvi import RuuviTagSensor
 from ruuvitag_sensor.ruuvitag import RuuviTag


### PR DESCRIPTION
Here's some initial work on #30.

Data field names now match RuuviCollector names on InfluxDB examples. 
Data format field has been added and URL format 4 (with identifier) has been added. 
Additionally nosetests now run on Python 2.

A few issues to consider before merging:
 * Battery voltage is now in mV in format 3, V in format 5 (incorrectly). RuuviCollector uses V. Which one should be used? 
 * RuuviCollector has a default database name of "ruuvi" and  measurement "ruuvi_measurements". Should these be changed?
