### PR TITLE
Fix batteryVoltage on Influx example. Use 'ruuvi' as database name

### DIFF
--- a/examples/post_to_influxdb.py
+++ b/examples/post_to_influxdb.py
@@ -47,9 +47,9 @@ def convert_to_influx(mac, payload):
     fields["accelerationX"]             = payload["acceleration_x"] if ('acceleration_x' in payload) else None
     fields["accelerationY"]             = payload["acceleration_y"] if ('acceleration_y' in payload) else None
     fields["accelerationZ"]             = payload["acceleration_z"] if ('acceleration_z' in payload) else None
-    fields["batteryVoltage"]            = payload["battery"]/1000.0 if hasattr(payload, 'battery') else None
+    fields["batteryVoltage"]            = payload["battery"]/1000.0 if ('battery' in payload) else None
     fields["txPower"]                   = payload["tx_power"] if ('tx_power' in payload) else None
-    fields["movementCounter"]           = payload["battery"] if ('battery' in payload) else None
+    fields["movementCounter"]           = payload["movement_counter"] if ('movement_counter' in payload) else None
     fields["measurementSequenceNumber"] = payload["measurement_sequence_number"] if ('measurement_sequence_number' in payload) else None
     fields["tagID"]                     = payload["tagID"] if ('tagID' in payload) else None
     fields["rssi"]                      = payload["rssi"] if ('rssi' in payload) else None

--- a/examples/post_to_influxdb_rx.py
+++ b/examples/post_to_influxdb_rx.py
@@ -7,8 +7,7 @@ Check guide and requirements from post_to_influxdb.py
 from influxdb import InfluxDBClient
 from ruuvitag_sensor.ruuvi_rx import RuuviTagReactive
 
-client = InfluxDBClient(host="localhost", port=8086, database="ruuvitag")
-
+client = InfluxDBClient(host="localhost", port=8086, database="ruuvi")
 
 def write_to_influxdb(received_data):
     '''
@@ -22,9 +21,9 @@ def write_to_influxdb(received_data):
     fields["accelerationX"]             = received_data[1]["acceleration_x"] if ('acceleration_x' in received_data[1]) else None
     fields["accelerationY"]             = received_data[1]["acceleration_y"] if ('acceleration_y' in received_data[1]) else None
     fields["accelerationZ"]             = received_data[1]["acceleration_z"] if ('acceleration_z' in received_data[1]) else None
-    fields["batteryVoltage"]            = received_data[1]["battery"]/1000.0 if hasattr(received_data[1], 'battery') else None
+    fields["batteryVoltage"]            = received_data[1]["battery"]/1000.0 if ('battery' in received_data[1]) else None
     fields["txPower"]                   = received_data[1]["tx_power"] if ('tx_power' in received_data[1]) else None
-    fields["movementCounter"]           = received_data[1]["battery"] if ('battery' in received_data[1]) else None
+    fields["movementCounter"]           = received_data[1]["movement_counter"] if ('movement_counter' in received_data[1]) else None
     fields["measurementSequenceNumber"] = received_data[1]["measurement_sequence_number"] if ('measurement_sequence_number' in received_data[1]) else None
     fields["tagID"]                     = received_data[1]["tagID"] if ('tagID' in received_data[1]) else None
     fields["rssi"]                      = received_data[1]["rssi"] if ('rssi' in received_data[1]) else None


### PR DESCRIPTION
* Fixes #61 
* Fixes battery voltage being placed into measurement counter
* DB name changed into "Ruuvi" on post_to_influxdb_rx.py
* Tested on RPi3 / Python 2
* Verification.py passes