### PR TITLE
Add missing device argument to hci commands

### DIFF
--- a/ruuvitag_sensor/ble_communication.py
+++ b/ruuvitag_sensor/ble_communication.py
@@ -75,8 +75,8 @@ class BleCommunicationNix(BleCommunication):
             log.info('Problem with hciconfig reset. Exit.')
             exit(1)
 
-        hcitool = ptyprocess.PtyProcess.spawn(['sudo', '-n', 'hcitool', 'lescan2', '--duplicates'])
-        hcidump = ptyprocess.PtyProcess.spawn(['sudo', '-n', 'hcidump', '--raw'])
+        hcitool = ptyprocess.PtyProcess.spawn(['sudo', '-n', 'hcitool', '-i', bt_device, 'lescan2', '--duplicates'])
+        hcidump = ptyprocess.PtyProcess.spawn(['sudo', '-n', 'hcidump', '-i', bt_device, '--raw'])
         return (hcitool, hcidump)
 
     @staticmethod


### PR DESCRIPTION
Bluetooth device can be specified but the device given (**bt_device**) is never actually used.

I tried to use USB dongle to catch beacon broadcasts instead of laptop's native Bluetooth device. This did not work because it was trying to use laptop's Bluetooth device no matter what I gave as **bt_device**.