### PR TITLE
Linting and testing with tox and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,15 @@
 sudo: false
 language: python
+os:
+  - linux
 python:
+    - "2.7"
     - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"
 install: pip install tox-travis
 script: tox
+jobs:
+  allow_failures:
+    - python: "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: python
+python:
+    - "3.5"
+    - "3.6"
+    - "3.7"
+    - "3.8"
+install: pip install tox-travis
+script: tox

--- a/developer_notes.md
+++ b/developer_notes.md
@@ -47,6 +47,11 @@ $ sudo python3 ruuvitag_sensor --help
      * Helper class to be used to handle singe RuuviTag and it's state.
 
 
+## Testing
+To check that your changes work across multiple python versions and platforms, we have tox. 
+You can run tox locally, but tox will only run your current platform and the python versions 
+you have in your system. Travis, however, will pick up all the combinations and test the all.
+
 ## Update RuuviTag firmware and change modes
 
 1. Download firmware from https://lab.ruuvi.com/dfu

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests/

--- a/ruuvitag_sensor/data_formats.py
+++ b/ruuvitag_sensor/data_formats.py
@@ -33,7 +33,8 @@ class DataFormats(object):
     @staticmethod
     def _get_data_format_2and4(raw):
         """
-        Validate that data is from RuuviTag and is Data Format 2 or 4. Convert hexadcimal data to string.
+        Validate that data is from RuuviTag and is Data Format 2 or 4.
+        Convert hexadcimal data to string.
         Encoded data part is after ruu.vi/#
 
         Returns:
@@ -62,7 +63,8 @@ class DataFormats(object):
         Returns:
             string: Sensor data
         """
-        # Search of FF990403 (Manufacturer Specific Data (FF) / Ruuvi Innovations ltd (9904) / Format 3 (03))
+        # Search of FF990403 (Manufacturer Specific Data (FF) /
+        # Ruuvi Innovations ltd (9904) / Format 3 (03))
         try:
             if 'FF990403' not in raw:
                 return None
@@ -80,7 +82,8 @@ class DataFormats(object):
         Returns:
             string: Sensor data
         """
-        # Search of FF990405 (Manufacturer Specific Data (FF) / Ruuvi Innovations ltd (9904) / Format 5 (05))
+        # Search of FF990405 (Manufacturer Specific Data (FF) /
+        # Ruuvi Innovations ltd (9904) / Format 5 (05))
         try:
             if 'FF990405' not in raw:
                 return None

--- a/ruuvitag_sensor/decoder.py
+++ b/ruuvitag_sensor/decoder.py
@@ -149,7 +149,8 @@ class Df3Decoder(object):
                 'humidity': self._get_humidity(byte_data),
                 'temperature': self._get_temperature(byte_data),
                 'pressure': self._get_pressure(byte_data),
-                'acceleration': math.sqrt(acc_x * acc_x + acc_y * acc_y + acc_z * acc_z),
+                'acceleration': math.sqrt(
+                    acc_x * acc_x + acc_y * acc_y + acc_z * acc_z),
                 'acceleration_x': acc_x,
                 'acceleration_y': acc_y,
                 'acceleration_z': acc_z,

--- a/ruuvitag_sensor/log.py
+++ b/ruuvitag_sensor/log.py
@@ -12,7 +12,9 @@ file_handler = logging.FileHandler('ruuvitag_sensor.log')
 file_handler.setLevel(logging.ERROR)
 
 # create a logging format
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter(
+    '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    )
 file_handler.setFormatter(formatter)
 
 # add the handlers to the logger

--- a/ruuvitag_sensor/ruuvi_rx.py
+++ b/ruuvitag_sensor/ruuvi_rx.py
@@ -1,10 +1,9 @@
-from datetime import datetime
-from multiprocessing import Manager
-from threading import Thread
 import time
-from concurrent.futures import ProcessPoolExecutor
+from threading import Thread
+from datetime import datetime
 from rx.subjects import Subject
-
+from multiprocessing import Manager
+from concurrent.futures import ProcessPoolExecutor
 from ruuvitag_sensor.ruuvi import RuuviTagSensor, RunFlag
 
 
@@ -27,13 +26,15 @@ def _run_get_data_background(macs, queue, shared_data, bt_device):
 
 class RuuviTagReactive(object):
     """
-    Reactive wrapper and background process for RuuviTagSensor get_datas
+    Reactive wrapper and background process for RuuviTagSensor
+    get_datas
     """
 
     @staticmethod
     def _data_update(subjects, queue, run_flag):
         """
-        Get data from backgound process and notify all subscribed observers with the new data
+        Get data from backgound process and notify all subscribed observers
+        with the new data
         """
         while run_flag.running:
             while not queue.empty():
@@ -44,7 +45,8 @@ class RuuviTagReactive(object):
 
     def __init__(self, macs=[], bt_device=''):
         """
-        Start background process for get_datas and async task for notifying all subscribed observers
+        Start background process for get_datas and async task for notifying
+        all subscribed observers
 
         Args:
             macs (list): MAC addresses
@@ -62,12 +64,16 @@ class RuuviTagReactive(object):
         self._shared_data['run_flag'] = True
 
         # Start data updater
-        notify_thread = Thread(target=RuuviTagReactive._data_update, args=(self._subjects, q, self._run_flag))
+        notify_thread = Thread(
+            target=RuuviTagReactive._data_update, 
+            args=(self._subjects, q, self._run_flag))
         notify_thread.start()
 
         # Start background process
         executor = ProcessPoolExecutor(1)
-        executor.submit(_run_get_data_background, macs, q, self._shared_data, bt_device)
+        executor.submit(
+            _run_get_data_background,
+            macs, q, self._shared_data, bt_device)
 
     def get_subject(self):
         """

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,24 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py27,py35,py36,py37,py38-{basic_linux,basic_macos}  # Todo add basic_windows
 
 [testenv]
+# environment will be skipped if regular expression does not match against the sys.platform string
+# https://tox.readthedocs.io/en/latest/example/platform.html
+platform = basic_linux: linux
+           basic_macos: darwin
+           # basic_windows: win32
+
 setenv =
     PYTHONPATH = {toxinidir}
     CI = True
+
 # install pytest in the virtualenv where commands will be executed
 deps = pytest
        mock
 
-commands =
-    # NOTE: you can run any command line tool here - not just tests
-    python setup.py install && pytest
+# upon tox invocation you will be greeted according to your platform
+commands=
+   basic_linux: python setup.py install && pytest
+   basic_macos: python setup.py install && pytest
+   # basic_windows: python setup.py install && pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+# content of: tox.ini , put in same dir as setup.py
+[tox]
+envlist = py35,py36,py37,py38
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}
+    CI = True
+# install pytest in the virtualenv where commands will be executed
+deps = pytest
+       mock
+
+commands =
+    # NOTE: you can run any command line tool here - not just tests
+    python setup.py install && pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py27,py35,py36,py37,py38-{basic_linux,basic_macos}  # Todo add basic_windows
+minversion = 2.0
+envlist = py{27,35,36,37,38}-{basic_linux,basic_macos}  # Todo add basic_windows
 
 [testenv]
 # environment will be skipped if regular expression does not match against the sys.platform string
@@ -12,13 +13,12 @@ platform = basic_linux: linux
 setenv =
     PYTHONPATH = {toxinidir}
     CI = True
-
+    
 # install pytest in the virtualenv where commands will be executed
 deps = pytest
        mock
 
 # upon tox invocation you will be greeted according to your platform
-commands=
-   basic_linux: python setup.py install && pytest
-   basic_macos: python setup.py install && pytest
-   # basic_windows: python setup.py install && pytest
+commands = basic_linux: pytest
+           basic_macos: pytest
+           # basic_windows: python setup.py install && pytest


### PR DESCRIPTION
Using tox will allow testing with multi python envs + multi platform (linux + osx). Right now Travis is not so kind on osx, so let's cross that bridge when we get there.

<img width="1088" alt="Screenshot 2020-01-04 at 1 08 32" src="https://user-images.githubusercontent.com/5014629/71754609-913b3900-2e8f-11ea-9416-9b81855bc75c.png">

As requested by @ttu this should still support py27 although python 2.x is now officially deprecated since 1st of Jan.

Later for windows Appvoyer can be used with tox as well: 
https://www.appveyor.com/docs/lang/python/


