### PR TITLE
Pin rx to version <3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='ruuvitag_sensor',
       ],
       keywords='RuuviTag BLE',
       install_requires=[
-          'rx',
+          'rx<3',
           'futures;python_version<"3.3"',
           'ptyprocess;platform_system=="Linux"'
       ],


### PR DESCRIPTION
Superseeds #102 (see that PR conversation history)

The gist is: If not pinned this will install version 3 which leads to an error - See https://github.com/ttu/ruuvitag-sensor/pull/99#issuecomment-592154395