### PR TITLE
Add deprecation warnings for outdated protocols

### DIFF
--- a/ruuvitag_sensor/decoder.py
+++ b/ruuvitag_sensor/decoder.py
@@ -17,10 +17,16 @@ def get_decoder(data_type):
         object: Data decoder
     """
     if data_type == 2:
+        log.warning("DATA TYPE 2 IS OBSOLETE. UPDATE YOUR TAG")
+        # https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_04.md
         return UrlDecoder()
     if data_type == 4:
+        log.warning("DATA TYPE 4 IS OBSOLETE. UPDATE YOUR TAG")
+        # https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_04.md
         return UrlDecoder()
     if data_type == 3:
+        log.warning("DATA TYPE 3 IS DEPRECATED - UPDATE YOUR TAG")
+        # https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_03.md
         return Df3Decoder()
     return Df5Decoder()
 


### PR DESCRIPTION
As of 11 days ago, Ruuvi marked older protocols as obsolete or deprecated.

https://github.com/ruuvi/ruuvi-sensor-protocols/commit/cded741930b8fc4803158f415cd94531e6bcadaa

https://github.com/ruuvi/ruuvi-sensor-protocols/commit/4b3a50783bcd5896c619e8bd179bd29dec00ca18

https://github.com/ruuvi/ruuvi-sensor-protocols/commit/7b41b162e967684e8921c1ebab6848c79f6177f2

Its nice to give warnings to people with outdated tags so that they can update them. 
Also note that protocol 08 is in specs, so that final clause `return Df5Decoder()` might break in the near future with encrypted data formats. 