### PR TITLE
bleson: avoid wrong result form get_data() if get_datas() returns before the desired mac is seen.

### DIFF
--- a/ruuvitag_sensor/adapters/bleson.py
+++ b/ruuvitag_sensor/adapters/bleson.py
@@ -116,11 +116,11 @@ class BleCommunicationBleson(BleCommunication):
     def get_data(mac, bt_device=''):
         data = None
         data_iter = BleCommunicationBleson.get_datas([], bt_device)
-        for data in data_iter:
-            if mac == data[0]:
+        for d in data_iter:
+            if mac == d[0]:
                 log.info('Data found')
                 data_iter.send(StopIteration)
-                data = data[1]
+                data = d[1]
                 break
 
         return data


### PR DESCRIPTION
I ran into this while experimenting with some changes to get_datas. I'm not sure whether this can actually happen as the code is now, so up to you whether you want to merge this.