### PR TITLE
Add entry point protection to some examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,11 @@ def handle_data(found_data):
     print('MAC ' + found_data[0])
     print(found_data[1])
 
-RuuviTagSensor.get_datas(handle_data)
+if __name_ == '__main__':
+    RuuviTagSensor.get_datas(handle_data)
 ```
+
+The line `if __name__ == "__main__":` is required on Windows and macOS due to the way the `multiprocessing` library works. It is not required on Linux, but it is recommended. It is omitted from the rest of the examples below.
 
 Optional list of macs and run flag can be passed to the get_datas function. Callback is called only for macs in the list and setting run flag to false will stop execution. If run flag is not passed, function will execute forever.
 

--- a/examples/find_tags.py
+++ b/examples/find_tags.py
@@ -8,4 +8,5 @@ import ruuvitag_sensor.log
 ruuvitag_sensor.log.enable_console()
 
 # This will print sensor's mac and state when new sensor is found
-RuuviTagSensor.find_ruuvitags()
+if __name__ == "__main__":
+    RuuviTagSensor.find_ruuvitags()

--- a/examples/http_server.py
+++ b/examples/http_server.py
@@ -19,9 +19,6 @@ from ruuvitag_sensor.ruuvi import RuuviTagSensor
 
 app = Flask(__name__)
 
-m = Manager()
-q = m.Queue()
-
 allData = {}
 
 tags = {
@@ -70,6 +67,9 @@ def get_data(mac):
 
 
 if __name__ == '__main__':
+    m = Manager()
+    q = m.Queue()
+
     # Start background process
     executor = ProcessPoolExecutor(1)
     executor.submit(run_get_data_background, list(tags.keys()), q)

--- a/examples/post_to_influxdb.py
+++ b/examples/post_to_influxdb.py
@@ -70,5 +70,5 @@ def write_to_influxdb(received_data):
     ]
     client.write_points(json_body)
 
-
-RuuviTagSensor.get_datas(write_to_influxdb)
+if __name__ == "__main__":
+    RuuviTagSensor.get_datas(write_to_influxdb)

--- a/examples/post_to_server.py
+++ b/examples/post_to_server.py
@@ -20,11 +20,13 @@ timeout_in_sec = 4
 
 url = 'http://localhost:8000/data/'
 
-datas = RuuviTagSensor.get_data_for_sensors(macs, timeout_in_sec)
+if __name__ == "__main__":
 
-# Use Requests to POST datas in json-format
-# Encode mac as it contains semicolon, which is reserved character
-for key, value in datas.items():
-    # url e.g.: http://localhost:8000/data/F4%3AA5%3A74%3A89%3A16%3A57
-    # json e.g.: {"temperature": 24.0, "humidity": 38.0, "pressure": 1018.0}
-    requests.post(url + quote(key), json=value)
+    datas = RuuviTagSensor.get_data_for_sensors(macs, timeout_in_sec)
+
+    # Use Requests to POST datas in json-format
+    # Encode mac as it contains semicolon, which is reserved character
+    for key, value in datas.items():
+        # url e.g.: http://localhost:8000/data/F4%3AA5%3A74%3A89%3A16%3A57
+        # json e.g.: {"temperature": 24.0, "humidity": 38.0, "pressure": 1018.0}
+        requests.post(url + quote(key), json=value)

--- a/examples/print_to_screen.py
+++ b/examples/print_to_screen.py
@@ -39,5 +39,5 @@ def print_data(received_data):
     print(line_pre)
     print('\n\r\n\r.......')
 
-
-RuuviTagSensor.get_datas(print_data, mac)
+if __name__ == "__main__":
+    RuuviTagSensor.get_datas(print_data, mac)

--- a/examples/send_updated_async.py
+++ b/examples/send_updated_async.py
@@ -74,12 +74,12 @@ def run_get_datas_background(queue):
 
     RuuviTagSensor.get_datas(handle_new_data)
 
+if __name__ == "__main__":
+    m = Manager()
+    q = m.Queue()
 
-m = Manager()
-q = m.Queue()
+    executor = ProcessPoolExecutor()
+    executor.submit(run_get_datas_background, q)
 
-executor = ProcessPoolExecutor()
-executor.submit(run_get_datas_background, q)
-
-loop = asyncio.get_event_loop()
-loop.run_until_complete(handle_queue(q))
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(handle_queue(q))


### PR DESCRIPTION
Fixes #123 for some of the examples. I could not test every example, but at least (on my Macbook) the ones changed in this commit crash before and work after the change.

To summarize: On Windows and macOS, the `multiprocessing` library generally requires that the main code is protected so it is only run once at the main entry point, because on these platforms the default way of making new threads involves essentially `import`ing the code. This means adding `if __name__ == '__main__'` around the main part. Lack of this protection caused the examples to crash on macOS and probably on Windows.

Also made the same changes to the example code in README.md, to potentially unconfuse new users who probably look at that before the example files.