### PR TITLE
Rename methods returning first data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### [Unreleased]
+* CHANGE: RuuviTagSensor get_data-method renamed to get_first_raw_data
 * CHANGE: Switch unit test framework from nose to pytest
 * CHANGE: Support only Python 3.7 and above
 * CHANGE: Updated RxPy to v4

--- a/ruuvitag_sensor/adapters/__init__.py
+++ b/ruuvitag_sensor/adapters/__init__.py
@@ -7,7 +7,7 @@ class BleCommunication(object):
 
     @staticmethod
     @abc.abstractmethod
-    def get_data(mac, bt_device=''):
+    def get_first_data(mac, bt_device=''):
         pass
 
     @staticmethod

--- a/ruuvitag_sensor/adapters/bleson.py
+++ b/ruuvitag_sensor/adapters/bleson.py
@@ -130,7 +130,7 @@ class BleCommunicationBleson(BleCommunication):
         return
 
     @staticmethod
-    def get_data(mac, bt_device=''):
+    def get_first_data(mac, bt_device=''):
         data = None
         data_iter = BleCommunicationBleson.get_datas([], bt_device)
         for d in data_iter:

--- a/ruuvitag_sensor/adapters/dummy.py
+++ b/ruuvitag_sensor/adapters/dummy.py
@@ -5,7 +5,7 @@ class BleCommunicationDummy(BleCommunication):
     """TODO: Find some working BLE implementation for Windows and OSX"""
 
     @staticmethod
-    def get_data(mac, bt_device=''):
+    def get_first_data(mac, bt_device=''):
         return '1E0201060303AAFE1616AAFE10EE037275752E76692F23416A7759414D4663CD'
 
     @staticmethod

--- a/ruuvitag_sensor/adapters/nix_hci.py
+++ b/ruuvitag_sensor/adapters/nix_hci.py
@@ -165,7 +165,7 @@ class BleCommunicationNix(BleCommunication):
 
         self.stop(procs[0], procs[1])
 
-    def get_data(self, mac, bt_device=''):
+    def get_first_data(self, mac, bt_device=''):
         data = None
         data_iter = self.get_datas([], bt_device)
         for data in data_iter:

--- a/ruuvitag_sensor/ruuvi.py
+++ b/ruuvitag_sensor/ruuvi.py
@@ -43,7 +43,7 @@ class RuuviTagSensor(object):
     """
 
     @staticmethod
-    def get_data(mac, bt_device=''):
+    def get_first_raw_data(mac, bt_device=''):
         """
         Get raw data for selected RuuviTag
 

--- a/ruuvitag_sensor/ruuvi.py
+++ b/ruuvitag_sensor/ruuvi.py
@@ -54,7 +54,7 @@ class RuuviTagSensor(object):
             tuple (int, string): Data Format type and raw Sensor data
         """
 
-        raw = ble.get_data(mac, bt_device)
+        raw = ble.get_first_data(mac, bt_device)
         return DataFormats.convert_data(raw)
 
     @staticmethod

--- a/ruuvitag_sensor/ruuvitag.py
+++ b/ruuvitag_sensor/ruuvitag.py
@@ -37,7 +37,7 @@ class RuuviTag(object):
             dict: Latest state
         """
 
-        (data_format, data) = RuuviTagSensor.get_data(self._mac, self._bt_device)
+        (data_format, data) = RuuviTagSensor.get_first_raw_data(self._mac, self._bt_device)
 
         if data == self._data:
             return self._state

--- a/tests/test_ruuvitag_sensor.py
+++ b/tests/test_ruuvitag_sensor.py
@@ -8,13 +8,13 @@ from ruuvitag_sensor.ruuvitag import RuuviTag
 
 class TestRuuviTagSensor():
 
-    def get_data(self, mac, bt_device):
+    def get_first_data(self, mac, bt_device):
         # https://ruu.vi/#AjwYAMFc
         data = '043E2A0201030157168974A5F41E0201060303AAFE1616AAFE10EE037275752E76692F23416A7759414D4663CD'
         return data[26:]
 
-    @patch('ruuvitag_sensor.adapters.nix_hci.BleCommunicationNix.get_data', get_data)
-    @patch('ruuvitag_sensor.adapters.dummy.BleCommunicationDummy.get_data', get_data)
+    @patch('ruuvitag_sensor.adapters.nix_hci.BleCommunicationNix.get_first_data', get_first_data)
+    @patch('ruuvitag_sensor.adapters.dummy.BleCommunicationDummy.get_first_data', get_first_data)
     def test_tag_update_is_valid(self):
         tag = RuuviTag('48:2C:6A:1E:59:3D')
 


### PR DESCRIPTION
Rename methods used for returning a single raw data. Part of https://github.com/ttu/ruuvitag-sensor/issues/157