### PR TITLE
Use typings in the whole codebase

### DIFF
--- a/ruuvitag_sensor/adapters/__init__.py
+++ b/ruuvitag_sensor/adapters/__init__.py
@@ -14,5 +14,5 @@ class BleCommunication(object):
 
     @staticmethod
     @abc.abstractmethod
-    def get_datas(blacklist: List(str) = [], bt_device: str = "") -> Iterator[Tuple[str, str]]:
+    def get_datas(blacklist: List[str] = [], bt_device: str = "") -> Iterator[Tuple[str, str]]:
         pass

--- a/ruuvitag_sensor/adapters/__init__.py
+++ b/ruuvitag_sensor/adapters/__init__.py
@@ -1,16 +1,18 @@
 import abc
+from typing import Iterator, List, Tuple
 
 
 class BleCommunication(object):
     """Bluetooth LE communication"""
+
     __metaclass__ = abc.ABCMeta
 
     @staticmethod
     @abc.abstractmethod
-    def get_first_data(mac, bt_device=''):
+    def get_first_data(mac: str, bt_device: str = "") -> str:
         pass
 
     @staticmethod
     @abc.abstractmethod
-    def get_datas(blacklist=[], bt_device=''):
+    def get_datas(blacklist: List(str) = [], bt_device: str = "") -> Iterator[Tuple[str, str]]:
         pass

--- a/ruuvitag_sensor/decoder.py
+++ b/ruuvitag_sensor/decoder.py
@@ -5,6 +5,8 @@ import math
 import logging
 import struct
 
+from ruuvitag_sensor.ruuvi_types import SensorData
+
 log = logging.getLogger(__name__)
 
 # pylint: disable=no-self-use
@@ -241,7 +243,7 @@ class Df5Decoder(object):
     def _get_mac(self, data):
         return ''.join('{:02x}'.format(x) for x in data[10:])
 
-    def decode_data(self, data):
+    def decode_data(self, data) -> SensorData:
         """
         Decode sensor data.
 

--- a/ruuvitag_sensor/ruuvi_types.py
+++ b/ruuvitag_sensor/ruuvi_types.py
@@ -1,0 +1,17 @@
+from typing import Optional, TypedDict
+
+
+class SensorData(TypedDict):
+    data_format: int
+    humidity: float
+    temperature: float
+    pressure: float
+    acceleration: float
+    acceleration_x: float
+    acceleration_y: float
+    acceleration_z: float
+    battery: int
+    tx_power: Optional[int]
+    movement_counter:  Optional[int]
+    measurement_sequence_number:  Optional[int]
+    mac: Optional[str]


### PR DESCRIPTION
After the package dropped support for Python2, types can be added to the whole codebase.