### PR TITLE
Parse data in find_ruuvitags_async()

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,14 @@ __NOTE:__ Asynchronous functionality is currently in beta-state and works only w
 import asyncio
 from ruuvitag_sensor.ruuvi import RuuviTagSensor
 
+
 async def main():
     async for found_data in RuuviTagSensor.get_data_async():
         print(f'MAC: {found_data[0]}')
         print(f'Data: {found_data[1]}')
 
 if __name__ == '__main__':
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 ```
 
 The optional list of MACs and run flag can be passed to the `get_data_async` function.
@@ -377,12 +378,16 @@ $ export RUUVI_BLE_ADAPTER="Bleak"
 Bleak supports only async methods.
 
 ```py
+import asyncio
+from ruuvitag_sensor.ruuvi import RuuviTagSensor
+
+
 async def main():
     async for data in RuuviTagSensor.get_data_async():
         print(data)
 
 if __name__ == '__main__':
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 ```
 
 Check [get_async_bleak](https://github.com/ttu/ruuvitag-sensor/blob/master/examples/get_async_bleak.py) from examples.

--- a/examples/get_async_bleak.py
+++ b/examples/get_async_bleak.py
@@ -13,4 +13,4 @@ async def main():
         print(data)
 
 if __name__ == '__main__':
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())

--- a/ruuvitag_sensor/ruuvi.py
+++ b/ruuvitag_sensor/ruuvi.py
@@ -129,9 +129,12 @@ class RuuviTagSensor(object):
         async for new_data in data_iter:
             if new_data[0] in data:
                 continue
-            data[new_data[0]] = new_data[1]
-            log.info(new_data[0])
-            log.info(new_data[1])
+
+            parsed_data = RuuviTagSensor._parse_data(new_data, mac_blacklist)
+            if parsed_data:
+                data[new_data[0]] = parsed_data
+                log.info(new_data[0])
+                log.info(parsed_data)
 
         return data
 


### PR DESCRIPTION
Data should be parsed before providing it to the user.

Also fix an asyncio DeprecationWarning in some examples and add missing
imports in one.

Fixes issue #175.