### PR TITLE
Add test case for asynchronous ruuvitags find

### DIFF
--- a/tests/test_ruuvitag_sensor_async.py
+++ b/tests/test_ruuvitag_sensor_async.py
@@ -10,6 +10,7 @@ from ruuvitag_sensor.adapters.dummy import BleCommunicationAsyncDummy
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="patch doesn't work correctly on 3.7")
+@pytest.mark.asyncio
 @patch('ruuvitag_sensor.ruuvi.ble', BleCommunicationAsyncDummy())
 class TestRuuviTagSensorAsync:
 
@@ -24,7 +25,6 @@ class TestRuuviTagSensorAsync:
             yield data
 
     @patch('ruuvitag_sensor.adapters.dummy.BleCommunicationAsyncDummy.get_data', _get_data)
-    @pytest.mark.asyncio
     async def test_get_data_async(self):
         data = []
         gener = RuuviTagSensor.get_data_async()
@@ -34,7 +34,6 @@ class TestRuuviTagSensorAsync:
         assert len(data) == 3
 
     @patch('ruuvitag_sensor.adapters.dummy.BleCommunicationAsyncDummy.get_data', _get_data)
-    @pytest.mark.asyncio
     async def test_get_data_async_with_macs(self):
         data = []
         macs = ['EB:A5:D1:02:CE:68', 'EC:4D:A7:95:08:6B']
@@ -44,7 +43,6 @@ class TestRuuviTagSensorAsync:
 
         assert len(data) == 2
 
-    @pytest.mark.asyncio
     @patch('ruuvitag_sensor.adapters.dummy.BleCommunicationAsyncDummy.get_data', _get_data)
     async def test_find_ruuvitags_async_with_bleak(self):
         tags = await RuuviTagSensor.find_ruuvitags_async()

--- a/tests/test_ruuvitag_sensor_async.py
+++ b/tests/test_ruuvitag_sensor_async.py
@@ -43,3 +43,10 @@ class TestRuuviTagSensorAsync:
             data.append(received)
 
         assert len(data) == 2
+
+    @pytest.mark.asyncio
+    @patch('ruuvitag_sensor.adapters.dummy.BleCommunicationAsyncDummy.get_data', _get_data)
+    async def test_find_ruuvitags_async_with_bleak(self):
+        tags = await RuuviTagSensor.find_ruuvitags_async()
+
+        assert len(tags) == 3

--- a/tests/test_ruuvitag_sensor_async.py
+++ b/tests/test_ruuvitag_sensor_async.py
@@ -4,14 +4,13 @@ from unittest.mock import patch
 import pytest
 
 from ruuvitag_sensor.ruuvi import RuuviTagSensor
-from ruuvitag_sensor.adapters.dummy import BleCommunicationAsyncDummy
+from ruuvitag_sensor.adapters.dummy import BleCommunicationAsyncDummy, BleCommunicationDummy
 
 # pylint: disable=line-too-long,unused-argument
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="patch doesn't work correctly on 3.7")
 @pytest.mark.asyncio
-@patch('ruuvitag_sensor.ruuvi.ble', BleCommunicationAsyncDummy())
 class TestRuuviTagSensorAsync:
 
     async def _get_data(self, blacklist=[], bt_device='') -> Tuple[str, str]:
@@ -24,6 +23,7 @@ class TestRuuviTagSensorAsync:
         for data in tag_data:
             yield data
 
+    @patch('ruuvitag_sensor.ruuvi.ble', BleCommunicationAsyncDummy())
     @patch('ruuvitag_sensor.adapters.dummy.BleCommunicationAsyncDummy.get_data', _get_data)
     async def test_get_data_async(self):
         data = []
@@ -33,6 +33,7 @@ class TestRuuviTagSensorAsync:
 
         assert len(data) == 3
 
+    @patch('ruuvitag_sensor.ruuvi.ble', BleCommunicationAsyncDummy())
     @patch('ruuvitag_sensor.adapters.dummy.BleCommunicationAsyncDummy.get_data', _get_data)
     async def test_get_data_async_with_macs(self):
         data = []
@@ -43,8 +44,21 @@ class TestRuuviTagSensorAsync:
 
         assert len(data) == 2
 
+    @patch('ruuvitag_sensor.ruuvi.ble', BleCommunicationAsyncDummy())
     @patch('ruuvitag_sensor.adapters.dummy.BleCommunicationAsyncDummy.get_data', _get_data)
     async def test_find_ruuvitags_async_with_bleak(self):
+        """Tests to see if MAC and the state of the sensors are returned for Bleak enabled request."""
         tags = await RuuviTagSensor.find_ruuvitags_async()
 
         assert len(tags) == 3
+
+    @patch('ruuvitag_sensor.ruuvi.ble', BleCommunicationDummy())
+    @patch('ruuvitag_sensor.adapters.dummy.BleCommunicationAsyncDummy.get_data', _get_data)
+    async def test_find_ruuvitags_async_without_bleak(self):
+        """Tests to see if exception is raised for non-Bleak enabled request.
+        
+        Async communication is supported only for BLE devices of subclass `BleCommunicationAsync`. This
+        test forces a non-compatible BLE device type (BleCommunicationDummy subclass) to raise Exception.
+        """
+        with pytest.raises(Exception):
+            tags = await RuuviTagSensor.find_ruuvitags_async()


### PR DESCRIPTION
Added test case for asynchronous ruuvitags find. The method name was with bleak, and another without since previously the test had `os.environ['RUUVI_BLE_ADAPTER'] = 'bleak'`.

The fail route of the test would have been:
```
@pytest.mark.asyncio
async def test_find_ruuvitags_async_without_bleak(self):
    os.environ['RUUVI_BLE_ADAPTER'] = ''

    with pytest.raises(Exception):
        result = await RuuviTagSensor.find_ruuvitags_async()
```
Now, since we're checking with the issubclass method, would we would need to move the global patch (`@patch('ruuvitag_sensor.ruuvi.ble', BleCommunicationAsyncDummy()`)
) to local?

For example, `@patch('ruuvitag_sensor.ruuvi.ble', BleCommunicationDummy()')` to force the exception.

Fixes #183 