### PR TITLE
Fix a Bleak deprecation warning

### DIFF
--- a/ruuvitag_sensor/adapters/development/dev_bleak_scanner.py
+++ b/ruuvitag_sensor/adapters/development/dev_bleak_scanner.py
@@ -31,12 +31,9 @@ data = [
 
 class DevBleakScanner():
 
-    def __init__(self, _):
-        self.callback: Union[Callable[[BLEDevice, AdvertisementData], Awaitable[None]], None] = None
+    def __init__(self, callback, _):
+        self.callback: Union[Callable[[BLEDevice, AdvertisementData], Awaitable[None]], None] = callback
         self.running: bool = False
-
-    def register_detection_callback(self, callback: Callable[[BLEDevice, AdvertisementData], Awaitable[None]]):
-        self.callback = callback
 
     async def start(self):
         self.running = True


### PR DESCRIPTION
The following warning is displayed when Bleak v0.18.0 is used: 
```
ruuvitag-sensor/ruuvitag_sensor/adapters/bleak_ble.py:79: \FutureWarning: This method will be removed in a future version of Bleak. Use the detection_callback of the BleakScanner constructor instead.
  scanner.register_detection_callback(detection_callback)
```

This warning is fixed by moving the callback function to the BleakScanner constructor.