### PR TITLE
Disable some pylint and fix mypy warnings

### DIFF
--- a/ruuvitag_sensor/adapters/__init__.py
+++ b/ruuvitag_sensor/adapters/__init__.py
@@ -64,5 +64,5 @@ class BleCommunicationAsync(object):
         # if False: yield is a mypy fix for
         # error: Return type "AsyncGenerator[Tuple[str, str], None]" of "get_data" incompatible with return type
         # "Coroutine[Any, Any, AsyncGenerator[Tuple[str, str], None]]" in supertype "BleCommunicationAsync"
-        if False:
+        if False:  # pylint: disable=unreachable,using-constant-test
             yield 0

--- a/ruuvitag_sensor/ruuvi.py
+++ b/ruuvitag_sensor/ruuvi.py
@@ -1,6 +1,7 @@
 import time
 import logging
 from multiprocessing import Manager
+from multiprocessing.managers import ListProxy
 from typing import AsyncGenerator, Callable, Dict, Generator, List, Optional
 from warnings import warn
 
@@ -237,7 +238,7 @@ class RuuviTagSensor(object):
                 yield data
 
     @staticmethod
-    def _parse_data(ble_data: MacAndRawData, mac_blacklist: List[str], allowed_macs: List[str] = []) \
+    def _parse_data(ble_data: MacAndRawData, mac_blacklist: ListProxy, allowed_macs: List[str] = []) \
             -> Optional[MacAndSensorData]:
         (mac, payload) = ble_data
         (data_format, data) = DataFormats.convert_data(payload)

--- a/ruuvitag_sensor/ruuvi_rx.py
+++ b/ruuvitag_sensor/ruuvi_rx.py
@@ -3,7 +3,7 @@ from threading import Thread
 from datetime import datetime
 from multiprocessing import Manager
 from multiprocessing.managers import DictProxy
-from multiprocessing.queues import Queue
+from queue import Queue
 from concurrent.futures import ProcessPoolExecutor
 from typing import List
 from reactivex import Subject
@@ -57,7 +57,7 @@ class RuuviTagReactive(object):
         """
 
         self._run_flag = RunFlag()
-        self._subjects = []
+        self._subjects: List[Subject] = []
 
         m = Manager()
         q = m.Queue()
@@ -87,7 +87,7 @@ class RuuviTagReactive(object):
         if not self._run_flag.running:
             raise Exception('RuuviTagReactive stopped')
 
-        subject = Subject()
+        subject: Subject = Subject()
         self._subjects.append(subject)
         return subject
 


### PR DESCRIPTION
Some mypy warnings still remain, see below. I was unable to fix them as I am unfamiliar with mypy.

```
ruuvitag_sensor/adapters/dummy.py:34: error: Return type "AsyncGenerator[Tuple[str, str], None]" of "get_data" incompatible with return type "Coroutine[Any, Any, AsyncGenerator[Tuple[str, str], None]]" in supertype "BleCommunicationAsync"
ruuvitag_sensor/adapters/bleak_ble.py:62: error: Return type "AsyncGenerator[Tuple[str, str], None]" of "get_data" incompatible with return type "Coroutine[Any, Any, AsyncGenerator[Tuple[str, str], None]]" in supertype "BleCommunicationAsync"
ruuvitag_sensor/ruuvi.py:114: error: Argument 2 to "_parse_data" of "RuuviTagSensor" has incompatible type "ListProxy[Any]"; expected "List[str]"
ruuvitag_sensor/ruuvi.py:160: error: Argument 2 to "_parse_data" of "RuuviTagSensor" has incompatible type "ListProxy[Any]"; expected "List[str]"
ruuvitag_sensor/ruuvi.py:236: error: Argument 2 to "_parse_data" of "RuuviTagSensor" has incompatible type "ListProxy[Any]"; expected "List[str]"
ruuvitag_sensor/ruuvi_rx.py:79: error: Argument 3 to "submit" of "Executor" has incompatible type "queue.Queue[Any]"; expected "multiprocessing.queues.Queue[Any]"
``` 