### PR TITLE
Make reactivex an optional dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The package provides 3 ways to fetch data from sensors:
 
 1. Synchronously with callback
 2. Asynchronously with async/await (BETA)
-3. Observable streams with ReactiveX
+3. Observable streams with ReactiveX (with the `rx` extra)
 
 RuuviTag sensors can be identified using MAC addresses. Methods return a tuple with MAC and sensor data payload.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,14 @@ classifiers = [
 ]
 keywords = [ "RuuviTag BLE" ]
 dependencies = [
-    "reactivex",
     "ptyprocess;platform_system=='Linux'",
     "mypy-extensions;python_version<'3.8'"
 ]
 
 [project.optional-dependencies]
+rx = [
+    "reactivex"
+]
 dev = [
     "pytest",
     "pytest-asyncio",

--- a/ruuvitag_sensor/ruuvi_rx.py
+++ b/ruuvitag_sensor/ruuvi_rx.py
@@ -6,8 +6,12 @@ from multiprocessing.managers import DictProxy
 from queue import Queue
 from concurrent.futures import ProcessPoolExecutor
 from typing import List
-from reactivex import Subject
 from ruuvitag_sensor.ruuvi import RuuviTagSensor, RunFlag
+
+try:
+    from reactivex import Subject
+except ImportError as ie:
+    raise ImportError('ReactiveX could not be imported (required for ruuvi_rx)') from ie
 
 
 def _run_get_data_background(macs: List[str], queue: Queue, shared_data: DictProxy, bt_device: str):


### PR DESCRIPTION
This PR makes `reactivex` an optional dependency that can be installed with the `rx` extra. (This could be a semver-major change for current users of the library.)

This is so that the library is more easily usable as purely a Ruuvitag data parser without it doing any of the actual Bluetooth comms itself (e.g. for inclusion in Home Assistant's built-in BLE stuff, which I'm working on).

Another option might be to split the parsing out to a separate library, but that feels more cumbersome.

What do you think?