### PR TITLE
fix: add rssi data to bleson adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### [Unreleased]
+* FIX: Add RSSI value to Bleson adapter payload
 
 ## [2.3.0] - 2023-09-23
 * FIX: Verify BLE adapter type before method execution

--- a/ruuvitag_sensor/adapters/bleak_ble.py
+++ b/ruuvitag_sensor/adapters/bleak_ble.py
@@ -9,6 +9,7 @@ from bleak import BleakScanner
 from bleak.backends.scanner import AdvertisementData, BLEDevice
 
 from ruuvitag_sensor.adapters import BleCommunicationAsync
+from ruuvitag_sensor.adapters.utils import rssi_to_hex
 from ruuvitag_sensor.ruuvi_types import MacAndRawData, RawData
 
 MAC_REGEX = "[0-9a-f]{2}([:])[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$"
@@ -74,7 +75,7 @@ class BleCommunicationBleak(BleCommunicationAsync):
             data = BleCommunicationBleak._parse_data(advertisement_data.manufacturer_data[1177])
 
             # Add RSSI to encoded data as hex. All adapters use a common decoder.
-            data += hex((advertisement_data.rssi + (1 << 8)) % (1 << 8)).replace("0x", "")
+            data += rssi_to_hex(advertisement_data.rssi)
             await queue.put((mac, data))
 
         scanner = _get_scanner(detection_callback)

--- a/ruuvitag_sensor/adapters/bleson.py
+++ b/ruuvitag_sensor/adapters/bleson.py
@@ -8,6 +8,7 @@ from typing import Generator, List
 from bleson import Observer, get_provider
 
 from ruuvitag_sensor.adapters import BleCommunication
+from ruuvitag_sensor.adapters.utils import rssi_to_hex
 from ruuvitag_sensor.ruuvi_types import MacAndRawData, RawData
 
 log = logging.getLogger(__name__)
@@ -56,6 +57,9 @@ class BleCommunicationBleson(BleCommunication):
                 data = f"FF{data.hex()}"
                 data = f"{(len(data) >> 1):02x}{data}"
                 data = f"{(len(data) >> 1):02x}{data}"
+
+                # Add RSSI to encoded data as hex. All adapters use a common decoder.
+                data += rssi_to_hex(advertisement.rssi)
                 queue.put((mac, data.upper()))
             except GeneratorExit:
                 break

--- a/ruuvitag_sensor/adapters/utils.py
+++ b/ruuvitag_sensor/adapters/utils.py
@@ -1,0 +1,2 @@
+def rssi_to_hex(rssi: int) -> str:
+    return f"{(rssi + (1 << 8)) % (1 << 8):x}"


### PR DESCRIPTION
Currently the Bleson adapter does not forward the `rssi` value. Its value is `None` instead. This PR pulls the data from the advertisement and converts it to hex just as in Bleak adapter and concats to the data. Seems to work with Raspberry Pi 3B+. I refactored the conversion to a util function. Please suggest a better place for it if needed.

Related issue:  #233 