### PR TITLE
build: lock black to last version with py37 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "pylint",
     "mypy",
     "isort",
-    "black"
+    "black==23.3.0"  # Lock black to the latest version that supports Python 3.7
 ]
 
 [project.urls]


### PR DESCRIPTION
https://black.readthedocs.io/en/latest/change_log.html#id55