### PR TITLE
docs: remove Python 2.7 reference from verification tests

### DIFF
--- a/developer_notes.md
+++ b/developer_notes.md
@@ -337,7 +337,7 @@ Or use e.g. VS Code to execute and debug tests.
 
 ## Exeuting Verification Test
 
-Verification test script executes a set of tests on active RuuviTags. Tests require at least one active RuuviTag and Python 2.7 and 3.x.
+Verification test script executes a set of tests on active RuuviTags. Tests require at least one active RuuviTag and Python 3.x.
 
 ```sh
 $ chmod +x verification.sh

--- a/verification.sh
+++ b/verification.sh
@@ -2,7 +2,6 @@
 
 rm -rf .venv_py
 
-# If python command is for 2.7, replace next line with: python3 -m venv .venv_py
 python -m venv .venv_py
 source .venv_py/bin/activate
 if [ "$1" = "pypi" ]; then


### PR DESCRIPTION
Also correspondingly update developer notes.

Python 2.7 support was dropped some time ago so removing it from verification.sh should be okay.