### PR TITLE
build: install Bleak by default on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### [Unreleased]
+* ADD: Install Bleak automatically on all platforms
 
 ## [2.3.1] - 2024-03-10
 * ADD: Bluez as option to RUUVI_BLE_ADAPTER environment variable

--- a/README.md
+++ b/README.md
@@ -445,15 +445,10 @@ In case of errors, the application tries to exit immediately, so it can be autom
 
 ### Bleak
 
-On Windows and macOS Bleak is installed and used automatically with `ruuvitag-sensor` package. 
+Bleak is automatically installed with `ruuvitag-sensor` package on all platforms.
+On Windows and macOS it is automatically used with `ruuvitag-sensor` package.
 
-On Linux install it manually from PyPI and enable it with `RUUVI_BLE_ADAPTER` environment variable.
-
-```sh
-$ python -m pip install bleak
-```
-
-Add environment variable RUUVI_BLE_ADAPTER with value Bleak. E.g.
+To enable Bleak use the `RUUVI_BLE_ADAPTER` environment variable as shown below.
 
 ```sh
 $ export RUUVI_BLE_ADAPTER="bleak"
@@ -467,7 +462,7 @@ import os
 os.environ["RUUVI_BLE_ADAPTER"] = "bleak"
 ```
 
-Bleak supports only async methods.
+Bleak only supports asynchronous methods.
 
 ```py
 import asyncio

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "ptyprocess;platform_system=='Linux'",
     "mypy-extensions;python_version<'3.8'",
     "importlib-metadata<4.3,>=1.1.0;python_version<'3.8'",
-    "bleak;platform_system=='Windows' or platform_system=='Darwin'",
+    "bleak",
 ]
 
 [project.optional-dependencies]

--- a/ruuvitag_sensor/adapters/bleak_ble.py
+++ b/ruuvitag_sensor/adapters/bleak_ble.py
@@ -28,8 +28,10 @@ def _get_scanner(detection_callback: AdvertisementDataCallback, bt_device: str =
 
     if bt_device:
         return BleakScanner(
-            detection_callback=detection_callback, scanning_mode=scanning_mode, adapter=bt_device
-        )  # type: ignore[arg-type]
+            detection_callback=detection_callback,
+            scanning_mode=scanning_mode,  # type: ignore[arg-type]
+            adapter=bt_device,
+        )
 
     return BleakScanner(detection_callback=detection_callback, scanning_mode=scanning_mode)  # type: ignore[arg-type]
 


### PR DESCRIPTION
As Bleak is soon to become the default adapter on Linux, install Bleak by default for the benefit of Linux users, both current and future. For future Bleak users this makes testing and adoption easier when the module is pre-installed.