### PR TITLE
build: drop Python 3.7 and 3.8 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### [Unreleased]
 * ADD: Install Bleak automatically on all platforms
 * CHANGE: Async Bleak adapter as default adapter on all platforms
+* CHANGE: Support only Python 3.9 and above
 
 ## [2.3.1] - 2024-03-10
 * ADD: Bluez as option to RUUVI_BLE_ADAPTER environment variable

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ RuuviTag Sensor Python Package
 [![License](https://img.shields.io/pypi/l/ruuvitag-sensor.svg)](https://pypi.python.org/pypi/ruuvitag-sensor/)
 [![PyPI version](https://img.shields.io/pypi/v/ruuvitag-sensor.svg)](https://pypi.python.org/pypi/ruuvitag_-sensor)
 [![PyPI downloads](https://img.shields.io/pypi/dm/ruuvitag-sensor.svg)](https://pypistats.org/packages/ruuvitag-sensor)
-[![Python versions](https://img.shields.io/badge/python-3.7+-blue.svg)](https://pypi.python.org/pypi/ruuvitag-sensor/)
+[![Python versions](https://img.shields.io/badge/python-3.9+-blue.svg)](https://pypi.python.org/pypi/ruuvitag-sensor/)
 
 `ruuvitag-sensor` is a Python package for communicating with [RuuviTag BLE Sensor](https://ruuvi.com/) and for decoding measurement data from broadcasted BLE data.
 
@@ -30,7 +30,8 @@ RuuviTag Sensor Python Package
     * [Install guide](#BlueZ)
     * __NOTE:__ The BlueZ-adapter implementation uses deprecated BlueZ tools that are no longer supported.
       * Bleson-adapter supports sync-methods, but please be aware that it is not fully supported due to the alpha release status of the Bleson communication module. See [Bleson](#Bleson) for more information.
-* Python 3.7+
+* Python 3.9+
+    * For Python 3.7 and 3.8 support, check [installation instructions](#python-37-and-38) for an older version
     * For Python 2.x or <3.7 support, check [installation instructions](#python-2x-and-36-and-below) for an older version
 
 __NOTE:__ Version 2.0 contains method renames. When using a version prior to 2.0, check the documentation and examples from [PyPI](https://pypi.org/project/ruuvitag-sensor/) or in GitHub, switch to the correct release tag from _switch branches/tags_.
@@ -504,6 +505,21 @@ __NOTE:__ On macOS, only Data Format 5 works, as macOS doesn't advertise MAC add
 
 __NOTE:__ On Windows, Bleson requires _Python 3.6_. Unfortunately on Windows, Bleson doesn't send any payload for the advertised package, so it is still unusable.
 
+
+## Python 3.7 and 3.8
+
+Last version of `ruuvitag-sensor` with Python 3.7 and 3.8 support is [2.3.1](https://pypi.org/project/ruuvitag-sensor/2.3.1/).
+
+[Branch](https://github.com/ttu/ruuvitag-sensor/tree/release/2.3.1) / [Tag / commit](https://github.com/ttu/ruuvitag-sensor/commit/b16c9580d75eafe5508d0551642eb3b022ae1325)
+
+```sh
+$ git checkout release/2.3.1
+```
+
+Install from PyPI
+```sh
+$ python -m pip install ruuvitag-sensor==2.3.1
+```
 
 ## Python 2.x and 3.6 and below
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,9 @@ authors = [
 description = "Find RuuviTag sensors and get decoded data from selected sensors"
 readme = "README.md"
 license = { file="LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -31,8 +29,6 @@ keywords = [ "RuuviTag BLE" ]
 dependencies = [
     "reactivex",
     "ptyprocess;platform_system=='Linux'",
-    "mypy-extensions;python_version<'3.8'",
-    "importlib-metadata<4.3,>=1.1.0;python_version<'3.8'",
     "bleak",
 ]
 
@@ -44,7 +40,7 @@ dev = [
     "pylint",
     "mypy",
     "isort",
-    "black==23.3.0"  # Lock black to the latest version that supports Python 3.7
+    "black"
 ]
 
 [project.urls]
@@ -79,7 +75,7 @@ disable = [
 ]
 
 [tool.mypy]
-python_version = 3.8
+python_version = 3.9
 ignore_missing_imports = true
 
 [tool.isort]

--- a/ruuvitag_sensor/__init__.py
+++ b/ruuvitag_sensor/__init__.py
@@ -1,8 +1,3 @@
-try:
-    import importlib.metadata  # >=3.8
+import importlib.metadata
 
-    __version__ = importlib.metadata.version(__package__ or __name__)  # pylint: disable=no-member
-except ImportError:
-    import importlib_metadata  # <=3.7
-
-    __version__ = importlib_metadata.version(__package__ or __name__)
+__version__ = importlib.metadata.version(__package__ or __name__)  # pylint: disable=no-member

--- a/ruuvitag_sensor/adapters/bleak_ble.py
+++ b/ruuvitag_sensor/adapters/bleak_ble.py
@@ -36,9 +36,7 @@ def _get_scanner(detection_callback: AdvertisementDataCallback, bt_device: str =
     return BleakScanner(detection_callback=detection_callback, scanning_mode=scanning_mode)  # type: ignore[arg-type]
 
 
-# TODO: Python 3.7 - TypeError: 'type' object is not subscriptable
-# queue = asyncio.Queue[Tuple[str, str]]()
-queue = asyncio.Queue()  # type: ignore
+queue = asyncio.Queue[Tuple[str, str]]()
 
 log = logging.getLogger(__name__)
 

--- a/ruuvitag_sensor/ruuvi.py
+++ b/ruuvitag_sensor/ruuvi.py
@@ -320,9 +320,7 @@ class RuuviTagSensor:
         mac_to_send = (
             mac
             if mac
-            else parse_mac(data_format, decoded["mac"])
-            if "mac" in decoded and decoded["mac"] is not None
-            else ""
+            else parse_mac(data_format, decoded["mac"]) if "mac" in decoded and decoded["mac"] is not None else ""
         )
 
         # Check whitelist using MAC from decoded data if advertised MAC is not available

--- a/ruuvitag_sensor/ruuvi_types.py
+++ b/ruuvitag_sensor/ruuvi_types.py
@@ -1,9 +1,4 @@
-from typing import Optional, Tuple, Union
-
-try:
-    from typing import TypedDict  # >=3.8
-except ImportError:
-    from mypy_extensions import TypedDict  # <=3.7
+from typing import Optional, Tuple, TypedDict, Union
 
 
 class SensorDataBase(TypedDict):

--- a/tests/test_ruuvitag_sensor_async.py
+++ b/tests/test_ruuvitag_sensor_async.py
@@ -1,5 +1,4 @@
 import asyncio
-import sys
 from typing import Tuple
 from unittest.mock import patch
 
@@ -12,7 +11,6 @@ from ruuvitag_sensor.ruuvitag import RuuviTagAsync
 # pylint: disable=unused-argument
 
 
-@pytest.mark.skipif(sys.version_info < (3, 8), reason="patch doesn't work correctly on 3.7")
 @pytest.mark.asyncio
 class TestRuuviTagSensorAsync:
     async def _get_first_data(self, mac, bt_device):


### PR DESCRIPTION
Official support for 3.7 has ended so support is now removed from this project.

As most downloads from PyPI come from version 3.10 or newer it has been decided to drop version 3.8 support.