### PR TITLE
refactor: fix asyncio DeprecationWarnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 ```
 
 The optional list of MACs can be passed to the `get_data_async` function.
@@ -111,10 +111,12 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 ```
 
 The line `if __name__ == "__main__":` is required on Windows and macOS due to the way the `multiprocessing` library works. It is not required on Linux, but it is recommended. It is omitted from the rest of the examples below.
+Due to limitations in the RuuviTag package's Bleak adapter, Python 3.10 or later is required to use `asyncio.run(main())`.
+If using Python 3.9, replace `asyncio.run(main())` with `asyncio.get_event_loop().run_until_complete(main())`.
 
 ### 2. Get sensor data synchronously with callback
 
@@ -468,7 +470,7 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 ```
 
 Check [get_async_bleak](https://github.com/ttu/ruuvitag-sensor/blob/master/examples/get_async_bleak.py) and other async examples from [examples](https://github.com/ttu/ruuvitag-sensor/tree/master/examples) directory.

--- a/examples/find_tags_async_bleak.py
+++ b/examples/find_tags_async_bleak.py
@@ -1,5 +1,5 @@
 """
-Asynchronous find RuuviTags
+Asynchronously find RuuviTags
 """
 
 import asyncio
@@ -11,8 +11,11 @@ ruuvitag_sensor.log.enable_console()
 
 
 async def main():
-    await RuuviTagSensor.find_ruuvitags_async()
+    try:
+        await RuuviTagSensor.find_ruuvitags_async()
+    except asyncio.exceptions.CancelledError:
+        print("Scan stopped")
 
 
 if __name__ == "__main__":
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())

--- a/examples/get_async_bleak.py
+++ b/examples/get_async_bleak.py
@@ -7,9 +7,14 @@ ruuvitag_sensor.log.enable_console()
 
 
 async def main():
-    async for data in RuuviTagSensor.get_data_async():
-        print(data)
+    try:
+        async for data in RuuviTagSensor.get_data_async():
+            print(data)
+    except asyncio.exceptions.CancelledError:
+        print("Scan stopped")
 
 
 if __name__ == "__main__":
-    asyncio.get_event_loop().run_until_complete(main())
+    # Note: Python 3.10 or later is required with asyncio.run
+    # For older versions of Python, use asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())

--- a/examples/get_first_async_bleak.py
+++ b/examples/get_first_async_bleak.py
@@ -21,4 +21,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())

--- a/examples/rx_async.py
+++ b/examples/rx_async.py
@@ -8,9 +8,12 @@ async def main():
     subject = ruuvi_rx.get_subject()
     subject.subscribe(print)
 
+    # keep coroutine alive
+    try:
+        await asyncio.get_running_loop().create_future()
+    finally:
+        ruuvi_rx.stop()
+
 
 if __name__ == "__main__":
-    # https://stackoverflow.com/a/56727859/1292530
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
-    loop.run_forever()
+    asyncio.run(main())

--- a/examples/send_updated_async.py
+++ b/examples/send_updated_async.py
@@ -78,5 +78,4 @@ if __name__ == "__main__":
     executor = ProcessPoolExecutor()
     executor.submit(run_get_data_background, q)
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(handle_queue(q))
+    asyncio.run(handle_queue(q))

--- a/ruuvitag_sensor/__main__.py
+++ b/ruuvitag_sensor/__main__.py
@@ -75,6 +75,6 @@ if __name__ == "__main__":
         sys.exit(0)
 
     if is_async_adapter(ruuvitag_sensor.ruuvi.ble):
-        asyncio.get_event_loop().run_until_complete(_async_main_handle(args))
+        asyncio.run(_async_main_handle(args))
     else:
         _sync_main_handle(args)

--- a/ruuvitag_sensor/ruuvi_rx.py
+++ b/ruuvitag_sensor/ruuvi_rx.py
@@ -91,7 +91,7 @@ class RuuviTagReactive:
         # Start background process
 
         if is_async_adapter(ble):
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             loop.create_task(_run_get_data_background_async(macs, q, self._shared_data, bt_device))
         else:
             executor = ProcessPoolExecutor(1)


### PR DESCRIPTION
Calling `get_event_loop()` in Python 3.12 and newer when no event loop is running is deprecated. The recommended option is to use `asyncio.run()` instead.

Fixes #246.