### PR TITLE
chore: use ruff for linting and code formatting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,17 +28,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[dev]
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --exit-zero
-    - name: Pylint
-      run: pylint ./ruuvitag_sensor
-    - name: Mypy
+    - name: ruff lint
+      run: ruff check ./ruuvitag_sensor
+    - name: mypy
       run: mypy ./ruuvitag_sensor
-    - name: isort
-      run: isort . --diff --check-only
-    - name: black
-      run: black . --check
+    - name: ruff format
+      run: ruff format --check
     - name: Tests
       run: pytest -v -s --show-capture all

--- a/developer_notes.md
+++ b/developer_notes.md
@@ -40,14 +40,9 @@ $ python -m pip install -e .[dev]
 $ python -m pip install -e .\[dev\]
 ```
 
-Flake8
+ruff
 ```sh
-$ flake8
-```
-
-Pylint
-```sh
-$ pylint ./ruuvitag_sensor/
+$ ruff check
 ```
 
 mypy
@@ -57,14 +52,9 @@ $ mypy ./ruuvitag_sensor/
 
 ## Formatting
 
-isort
+ruff
 ```sh
-$ isort .
-```
-
-black
-```sh
-$ black
+$ ruff format --check
 ```
 
 ## Project files

--- a/examples/http_server.py
+++ b/examples/http_server.py
@@ -42,7 +42,7 @@ def update_data():
     """
     Update data sent by background process to global all_data
     """
-    global all_data  # pylint: disable=global-variable-not-assigned
+    global all_data  # noqa: PLW0602
     while not q.empty():
         data = q.get()
         all_data[data[0]] = data[1]

--- a/examples/post_to_influxdb.py
+++ b/examples/post_to_influxdb.py
@@ -50,22 +50,20 @@ def write_to_influxdb(received_data):
     mac = received_data[0]
     payload = received_data[1]
 
-    dataFormat = payload["data_format"] if ("data_format" in payload) else None
+    dataFormat = payload.get("data_format", None)
     fields = {}
-    fields["temperature"] = payload["temperature"] if ("temperature" in payload) else None
-    fields["humidity"] = payload["humidity"] if ("humidity" in payload) else None
-    fields["pressure"] = payload["pressure"] if ("pressure" in payload) else None
-    fields["accelerationX"] = payload["acceleration_x"] if ("acceleration_x" in payload) else None
-    fields["accelerationY"] = payload["acceleration_y"] if ("acceleration_y" in payload) else None
-    fields["accelerationZ"] = payload["acceleration_z"] if ("acceleration_z" in payload) else None
+    fields["temperature"] = payload.get("temperature", None)
+    fields["humidity"] = payload.get("humidity", None)
+    fields["pressure"] = payload.get("pressure", None)
+    fields["accelerationX"] = payload.get("acceleration_x", None)
+    fields["accelerationY"] = payload.get("acceleration_y", None)
+    fields["accelerationZ"] = payload.get("acceleration_z", None)
     fields["batteryVoltage"] = payload["battery"] / 1000.0 if ("battery" in payload) else None
-    fields["txPower"] = payload["tx_power"] if ("tx_power" in payload) else None
-    fields["movementCounter"] = payload["movement_counter"] if ("movement_counter" in payload) else None
-    fields["measurementSequenceNumber"] = (
-        payload["measurement_sequence_number"] if ("measurement_sequence_number" in payload) else None
-    )
-    fields["tagID"] = payload["tagID"] if ("tagID" in payload) else None
-    fields["rssi"] = payload["rssi"] if ("rssi" in payload) else None
+    fields["txPower"] = payload.get("tx_power", None)
+    fields["movementCounter"] = payload.get("movement_counter", None)
+    fields["measurementSequenceNumber"] = payload.get("measurement_sequence_number", None)
+    fields["tagID"] = payload.get("tagID", None)
+    fields["rssi"] = payload.get("rssi", None)
     json_body = [
         {"measurement": "ruuvi_measurements", "tags": {"mac": mac, "dataFormat": dataFormat}, "fields": fields}
     ]

--- a/examples/post_to_influxdb_rx.py
+++ b/examples/post_to_influxdb_rx.py
@@ -30,24 +30,20 @@ def write_to_influxdb(received_data):
     """
     Convert data into RuuviCollector naming scheme and scale and write to InfluxDB.
     """
-    dataFormat = received_data[1]["data_format"] if ("data_format" in received_data[1]) else None
+    dataFormat = received_data[1].get("data_format", None)
     fields = {}
-    fields["temperature"] = received_data[1]["temperature"] if ("temperature" in received_data[1]) else None
-    fields["humidity"] = received_data[1]["humidity"] if ("humidity" in received_data[1]) else None
-    fields["pressure"] = received_data[1]["pressure"] if ("pressure" in received_data[1]) else None
-    fields["accelerationX"] = received_data[1]["acceleration_x"] if ("acceleration_x" in received_data[1]) else None
-    fields["accelerationY"] = received_data[1]["acceleration_y"] if ("acceleration_y" in received_data[1]) else None
-    fields["accelerationZ"] = received_data[1]["acceleration_z"] if ("acceleration_z" in received_data[1]) else None
+    fields["temperature"] = received_data[1].get("temperature", None)
+    fields["humidity"] = received_data[1].get("humidity", None)
+    fields["pressure"] = received_data[1].get("pressure", None)
+    fields["accelerationX"] = received_data[1].get("acceleration_x", None)
+    fields["accelerationY"] = received_data[1].get("acceleration_y", None)
+    fields["accelerationZ"] = received_data[1].get("acceleration_z", None)
     fields["batteryVoltage"] = received_data[1]["battery"] / 1000.0 if ("battery" in received_data[1]) else None
-    fields["txPower"] = received_data[1]["tx_power"] if ("tx_power" in received_data[1]) else None
-    fields["movementCounter"] = (
-        received_data[1]["movement_counter"] if ("movement_counter" in received_data[1]) else None
-    )
-    fields["measurementSequenceNumber"] = (
-        received_data[1]["measurement_sequence_number"] if ("measurement_sequence_number" in received_data[1]) else None
-    )
-    fields["tagID"] = received_data[1]["tagID"] if ("tagID" in received_data[1]) else None
-    fields["rssi"] = received_data[1]["rssi"] if ("rssi" in received_data[1]) else None
+    fields["txPower"] = received_data[1].get("tx_power", None)
+    fields["movementCounter"] = received_data[1].get("movement_counter", None)
+    fields["measurementSequenceNumber"] = received_data[1].get("measurement_sequence_number", None)
+    fields["tagID"] = received_data[1].get("tagID", None)
+    fields["rssi"] = received_data[1].get("rssi", None)
     json_body = [
         {
             "measurement": "ruuvi_measurements",

--- a/examples/post_to_mqtt.py
+++ b/examples/post_to_mqtt.py
@@ -53,7 +53,6 @@ location = args.location
 
 
 # let's trap ctrl-c, SIGINT and come down nicely
-# pylint: disable=unused-argument,redefined-outer-name
 def signal_handler(signal, frame):
     print("\nterminating gracefully.")
     client.disconnect()
@@ -64,9 +63,8 @@ signal.signal(signal.SIGINT, signal_handler)
 
 
 # The callback for when the client receives a CONNACK response from the MQTT server.
-# pylint: disable=unused-argument,redefined-outer-name
 def on_connect(client, userdata, flags, rc):
-    print(f"Connected to MQTT broker with result code {str(rc)}")
+    print(f"Connected to MQTT broker with result code {rc!s}")
 
     # Subscribing in on_connect() means that if we lose the connection and
     # reconnect then subscriptions will be renewed.

--- a/examples/print_to_screen.py
+++ b/examples/print_to_screen.py
@@ -10,8 +10,6 @@ Humidity:    28
 Pressure:    689
 """
 
-# pylint: disable=duplicate-code
-
 import os
 from datetime import datetime
 

--- a/examples/print_to_screen_ruuvitag_class.py
+++ b/examples/print_to_screen_ruuvitag_class.py
@@ -14,8 +14,6 @@ RuuviTag's update-method will always create new Bluetooth scanning
 process and eventually process creation may fail.
 """
 
-# pylint: disable=duplicate-code
-
 import os
 import time
 from datetime import datetime

--- a/examples/reactive_extensions.py
+++ b/examples/reactive_extensions.py
@@ -19,7 +19,7 @@ ruuvi_rx.get_subject().pipe(ops.filter(lambda x: x[0] == "F4:A5:74:89:16:57")).s
 # Print only last updated every 10 seconds for F4:A5:74:89:16:57
 ruuvi_rx.get_subject().pipe(ops.filter(lambda x: x[0] == "F4:A5:74:89:16:57"), ops.sample(interval_in_s)).subscribe(
     lambda data: print(data)
-)  # pylint: disable=unnecessary-lambda
+)
 
 # Print only last updated every 10 seconds for every foud sensor
 ruuvi_rx.get_subject().pipe(ops.group_by(lambda x: x[0])).subscribe(
@@ -29,9 +29,7 @@ ruuvi_rx.get_subject().pipe(ops.group_by(lambda x: x[0])).subscribe(
 # Print all from the last 10 seconds for F4:A5:74:89:16:57
 ruuvi_rx.get_subject().pipe(
     ops.filter(lambda x: x[0] == "F4:A5:74:89:16:57"), ops.buffer_with_time(interval_in_s)
-).subscribe(
-    lambda data: print(data)
-)  # pylint: disable=unnecessary-lambda
+).subscribe(lambda data: print(data))
 
 # Execute subscribe only once for F4:A5:74:89:16:57
 # when temperature goes over 80 degrees

--- a/examples/send_updated_async.py
+++ b/examples/send_updated_async.py
@@ -31,7 +31,7 @@ async def handle_queue(queue):
         async with session.post(
             f"{server_url}/sensordata", data=json.dumps(update_data), headers={"content-type": "application/json"}
         ) as response:
-            response = await response.read()
+            response = await response.read()  # noqa: PLW2901
 
     async def send_put(session, update_data):
         async with session.put(
@@ -39,7 +39,7 @@ async def handle_queue(queue):
             data=json.dumps(update_data),
             headers={"content-type": "application/json"},
         ) as response:
-            response = await response.read()
+            response = await response.read()  # noqa: PLW2901
 
     async with ClientSession() as session:
         while True:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,8 @@ dependencies = [
 dev = [
     "pytest",
     "pytest-asyncio",
-    "flake8-pyproject",
-    "pylint",
-    "mypy",
-    "isort",
-    "black"
+    "ruff",
+    "mypy"
 ]
 
 [project.urls]
@@ -53,35 +50,35 @@ changelog = "https://github.com/ttu/ruuvitag-sensor/blob/master/CHANGELOG.md"
 [tool.pytest.ini_options]
 testpaths = "tests/"
 
-[tool.flake8]
-exclude = ".venv, .git, .eggs, __pycache__, build, dist"
-max-line-length = 120
-ignore = "E402, E203"
-show-source = true
-max-complexity = 12
+[tool.ruff]
+exclude = [".venv", ".git", ".eggs", "__pycache__", "build", "dist"]
+line-length = 120
 
-[tool.pylint.messages_control]
-max-line-length = 120
-disable = [
-    "import-error",
-    "missing-docstring",
-    "invalid-name",
-    "bare-except",
-    "broad-except",
-    "broad-exception-raised",
-    "fixme",
-    "dangerous-default-value",
-    "too-few-public-methods",
-    "useless-object-inheritance"
+[tool.ruff.lint]
+select = [
+    "A",     # flake8-builtins
+    "C90",   # maccabe
+    "E",     # pycodestyle errors
+    "F",     # pyflakes
+    "G",     # flake8-logging-format
+    "I",     # isort
+    "PERF",  # perflint
+    "PIE",   # flake8-pie
+    "PL",    # pylint
+    "PTH",   # flake8-use-pathlib
+    "Q",     # flake8-quotes
+    "RUF",   # ruff-specific rules
+    "SIM",   # flake8-simplify
+    "W",     # pycodestyle warnings
 ]
+ignore = [
+    "PLR2004", # Magic value used in comparison
+    "RUF006",  # Store a reference to the return value of asyncio.create_task
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 12
 
 [tool.mypy]
 python_version = 3.9
 ignore_missing_imports = true
-
-[tool.isort]
-line_length = 120
-ensure_newline_before_comments = true
-
-[tool.black]
-line-length = 120

--- a/ruuvitag_sensor/__init__.py
+++ b/ruuvitag_sensor/__init__.py
@@ -1,3 +1,3 @@
 import importlib.metadata
 
-__version__ = importlib.metadata.version(__package__ or __name__)  # pylint: disable=no-member
+__version__ = importlib.metadata.version(__package__ or __name__)

--- a/ruuvitag_sensor/adapters/__init__.py
+++ b/ruuvitag_sensor/adapters/__init__.py
@@ -4,8 +4,6 @@ from typing import AsyncGenerator, Generator, List
 
 from ruuvitag_sensor.ruuvi_types import MacAndRawData, RawData
 
-# pylint: disable=import-outside-toplevel, cyclic-import, too-many-return-statements
-
 
 def get_ble_adapter():
     forced_ble_adapter = os.environ.get("RUUVI_BLE_ADAPTER", "").lower()
@@ -98,5 +96,5 @@ class BleCommunicationAsync:
         # if False: yield is a mypy fix for
         # error: Return type "AsyncGenerator[Tuple[str, str], None]" of "get_data" incompatible with return type
         # "Coroutine[Any, Any, AsyncGenerator[Tuple[str, str], None]]" in supertype "BleCommunicationAsync"
-        if False:  # pylint: disable=unreachable,using-constant-test
+        if False:
             yield 0

--- a/ruuvitag_sensor/adapters/bleak_ble.py
+++ b/ruuvitag_sensor/adapters/bleak_ble.py
@@ -21,7 +21,6 @@ def _get_scanner(detection_callback: AdvertisementDataCallback, bt_device: str =
     scanning_mode = "passive" if sys.platform.startswith("win") else "active"
 
     if "bleak_dev" in os.environ.get("RUUVI_BLE_ADAPTER", "").lower():
-        # pylint: disable=import-outside-toplevel
         from ruuvitag_sensor.adapters.development.dev_bleak_scanner import DevBleakScanner
 
         return DevBleakScanner(detection_callback, scanning_mode)

--- a/ruuvitag_sensor/adapters/bleson.py
+++ b/ruuvitag_sensor/adapters/bleson.py
@@ -13,8 +13,6 @@ from ruuvitag_sensor.ruuvi_types import MacAndRawData, RawData
 
 log = logging.getLogger(__name__)
 
-# pylint: disable=duplicate-code
-
 
 class BleCommunicationBleson(BleCommunication):
     """Bluetooth LE communication with Bleson"""
@@ -76,11 +74,8 @@ class BleCommunicationBleson(BleCommunication):
            device (string): BLE device (default 0)
         """
 
-        if not bt_device:
-            bt_device = 0
-        else:
-            # Old communication used hci0 etc.
-            bt_device = bt_device.replace("hci", "")
+        # Old communication used hci0 etc.
+        bt_device = 0 if not bt_device else bt_device.replace("hci", "")
 
         log.info("Start receiving broadcasts (device %s)", bt_device)
 

--- a/ruuvitag_sensor/adapters/development/dev_bleak_scanner.py
+++ b/ruuvitag_sensor/adapters/development/dev_bleak_scanner.py
@@ -33,11 +33,9 @@ class DevBleakScanner:
     async def start(self):
         self.running = True
         asyncio.create_task(self.run())
-        return None
 
     async def stop(self):
         self.running = False
-        return None
 
     async def run(self):
         while self.running:

--- a/ruuvitag_sensor/adapters/nix_hci.py
+++ b/ruuvitag_sensor/adapters/nix_hci.py
@@ -10,8 +10,6 @@ from ruuvitag_sensor.ruuvi_types import MacAndRawData, RawData
 
 log = logging.getLogger(__name__)
 
-# pylint: disable=duplicate-code
-
 
 class BleCommunicationNix(BleCommunication):
     """Bluetooth LE communication for Linux"""
@@ -24,12 +22,12 @@ class BleCommunicationNix(BleCommunication):
         """
         # import ptyprocess here so as long as all implementations are in
         # the same file, all will work
-        import ptyprocess  # pylint: disable=import-outside-toplevel
+        import ptyprocess
 
         if not bt_device:
             bt_device = "hci0"
 
-        is_root = os.getuid() == 0  # pylint: disable=no-member
+        is_root = os.getuid() == 0
 
         log.info("Start receiving broadcasts (device %s)", bt_device)
         DEVNULL = subprocess.DEVNULL
@@ -95,9 +93,8 @@ class BleCommunicationNix(BleCommunication):
                     data = line[2:].replace(" ", "")
                 elif line.startswith("< "):
                     data = None
-                else:
-                    if data:
-                        data += line.replace(" ", "")
+                elif data:
+                    data += line.replace(" ", "")
         except KeyboardInterrupt:
             return
         except Exception as ex:
@@ -112,7 +109,7 @@ class BleCommunicationNix(BleCommunication):
             log.debug("Parsing line %s", line)
             try:
                 # Make sure we're in upper case
-                line = line.upper()
+                line = line.upper()  # noqa: PLW2901
                 # We're interested in LE meta events, sent by Ruuvitags.
                 # Those start with "043E", followed by a length byte.
 

--- a/ruuvitag_sensor/adapters/nix_hci_file.py
+++ b/ruuvitag_sensor/adapters/nix_hci_file.py
@@ -1,5 +1,7 @@
 import logging
 
+import Path
+
 from ruuvitag_sensor.adapters.nix_hci import BleCommunicationNix
 
 log = logging.getLogger(__name__)
@@ -19,7 +21,7 @@ class BleCommunicationNixFile(BleCommunicationNix):
            This is interpreted as a file to open
         """
         log.info("Start reading from file %s", bt_device)
-        handle = open(bt_device, "rb")  # pylint: disable=consider-using-with
+        handle = Path.open(bt_device, "rb")
 
         return (None, handle)
 

--- a/ruuvitag_sensor/data_formats.py
+++ b/ruuvitag_sensor/data_formats.py
@@ -35,9 +35,8 @@ class DataFormats:
     RuuviTag broadcasted raw data handling for each data format
     """
 
-    # pylint: disable=too-many-return-statements
     @staticmethod
-    def convert_data(raw: str) -> DataFormatAndRawSensorData:
+    def convert_data(raw: str) -> DataFormatAndRawSensorData:  # noqa: PLR0911
         """
         Validate that data is from RuuviTag and get correct data part.
 
@@ -118,7 +117,7 @@ class DataFormats:
         return (None, None)
 
     @staticmethod
-    def _parse_raw(raw: str, data_format: int) -> str:  # pylint: disable=unused-argument
+    def _parse_raw(raw: str, data_format: int) -> str:
         return raw
 
     @staticmethod

--- a/ruuvitag_sensor/ruuvi.py
+++ b/ruuvitag_sensor/ruuvi.py
@@ -211,7 +211,7 @@ class RuuviTagSensor:
                 data = RuuviTagSensor._parse_data(ble_data, mac_blacklist, macs)
 
                 # Check MAC whitelist if advertised MAC available
-                if ble_data[0] and macs and not ble_data[0] in macs:
+                if ble_data[0] and macs and ble_data[0] not in macs:
                     log.debug("MAC not whitelisted: %s", ble_data[0])
                     continue
 
@@ -294,7 +294,7 @@ class RuuviTagSensor:
                 data_iter.close()
                 break
             # Check MAC whitelist if advertised MAC available
-            if ble_data[0] and macs and not ble_data[0] in macs:
+            if ble_data[0] and macs and ble_data[0] not in macs:
                 log.debug("MAC not whitelisted: %s", ble_data[0])
                 continue
 
@@ -331,7 +331,9 @@ class RuuviTagSensor:
         mac_to_send = (
             mac
             if mac
-            else parse_mac(data_format, decoded["mac"]) if "mac" in decoded and decoded["mac"] is not None else ""
+            else parse_mac(data_format, decoded["mac"])
+            if "mac" in decoded and decoded["mac"] is not None
+            else ""
         )
 
         # Check whitelist using MAC from decoded data if advertised MAC is not available

--- a/tests/test_data_formats.py
+++ b/tests/test_data_formats.py
@@ -1,7 +1,5 @@
 from ruuvitag_sensor.data_formats import DataFormats
 
-# pylint: disable=protected-access
-
 
 class TestDataFormats:
     def test_convert_data_valid_data(self):

--- a/tests/test_ruuvitag_sensor.py
+++ b/tests/test_ruuvitag_sensor.py
@@ -6,8 +6,6 @@ from ruuvitag_sensor.adapters.dummy import BleCommunicationDummy
 from ruuvitag_sensor.ruuvi import RuuviTagSensor
 from ruuvitag_sensor.ruuvitag import RuuviTag
 
-# pylint: disable=unused-argument
-
 
 @patch("ruuvitag_sensor.ruuvi.ble", BleCommunicationDummy())
 class TestRuuviTagSensor:

--- a/tests/test_ruuvitag_sensor_async.py
+++ b/tests/test_ruuvitag_sensor_async.py
@@ -8,8 +8,6 @@ from ruuvitag_sensor.adapters.dummy import BleCommunicationAsyncDummy, BleCommun
 from ruuvitag_sensor.ruuvi import RuuviTagSensor
 from ruuvitag_sensor.ruuvitag import RuuviTagAsync
 
-# pylint: disable=unused-argument
-
 
 @pytest.mark.asyncio
 class TestRuuviTagSensorAsync:
@@ -33,21 +31,17 @@ class TestRuuviTagSensorAsync:
     @patch("ruuvitag_sensor.ruuvi.ble", BleCommunicationAsyncDummy())
     @patch("ruuvitag_sensor.adapters.dummy.BleCommunicationAsyncDummy.get_data", _get_data)
     async def test_get_data_async(self):
-        data = []
         gener = RuuviTagSensor.get_data_async()
-        async for received in gener:
-            data.append(received)
+        data = [received async for received in gener]
 
         assert len(data) == 4
 
     @patch("ruuvitag_sensor.ruuvi.ble", BleCommunicationAsyncDummy())
     @patch("ruuvitag_sensor.adapters.dummy.BleCommunicationAsyncDummy.get_data", _get_data)
     async def test_get_data_async_with_macs(self):
-        data = []
         macs = ["EB:A5:D1:02:CE:68", "EC:4D:A7:95:08:6B"]
         gener = RuuviTagSensor.get_data_async(macs)
-        async for received in gener:
-            data.append(received)
+        data = [received async for received in gener]
 
         assert len(data) == 2
 

--- a/verification.py
+++ b/verification.py
@@ -83,7 +83,7 @@ print("OK")
 #
 print_header("RuuviTagSensor.get_data_for_sensors with macs")
 
-data = RuuviTagSensor.get_data_for_sensors(list(data.keys())[0], search_duration_sec=15)
+data = RuuviTagSensor.get_data_for_sensors(next(iter(data.keys())), search_duration_sec=15)
 print(data)
 
 if not data:
@@ -97,7 +97,7 @@ print("OK")
 #
 print_header("RuuviTag.update")
 
-tag = RuuviTag(list(data.keys())[0])
+tag = RuuviTag(next(iter(data.keys())))
 tag.update()
 print(tag.state)
 
@@ -147,7 +147,6 @@ def hadle_rx(found_data):
 
 ruuvi_rx.get_subject().subscribe(hadle_rx)
 
-# pylint: disable=protected-access
 wait_for_finish(ruuvi_rx._run_flag, "ruuvi_rx.subscribe")
 
 

--- a/verification_async.py
+++ b/verification_async.py
@@ -83,7 +83,7 @@ async def test_get_data_for_sensors_async() -> list[str]:
         raise Exception("FAILED")
 
     print("OK")
-    return list(data.keys())[0]
+    return next(iter(data.keys()))
 
 
 async def test_get_data_for_sensors_async_with_macs(mac: list[str]):
@@ -149,7 +149,6 @@ async def test_ruuvi_rx():
 
     ruuvi_rx.get_subject().subscribe(handle_rx)
 
-    # pylint: disable=protected-access
     await wait_for_finish(ruuvi_rx._run_flag, "ruuvi_rx.subscribe")
 
 


### PR DESCRIPTION
ruff replaces black, flake8, isort and pylint.

Fixes #241.