### PR TITLE
docs: fix port number in asyncio server examples

### DIFF
--- a/examples/http_server_asyncio.py
+++ b/examples/http_server_asyncio.py
@@ -3,8 +3,8 @@ Simple http server, that returns data in json.
 Executes get data for sensors in the background.
 
 Endpoints:
-    http://0.0.0.0:5000/data
-    http://0.0.0.0:5000/data/{mac}
+    http://0.0.0.0:5500/data
+    http://0.0.0.0:5500/data/{mac}
 
 Requires:
     asyncio - Python 3.5

--- a/examples/http_server_asyncio_rx.py
+++ b/examples/http_server_asyncio_rx.py
@@ -3,8 +3,8 @@ Simple http server, that returns data in json.
 Executes get data for sensors in the background.
 
 Endpoints:
-    http://0.0.0.0:5000/data
-    http://0.0.0.0:5000/data/{mac}
+    http://0.0.0.0:5500/data
+    http://0.0.0.0:5500/data/{mac}
 
 Requires:
     asyncio - Python 3.5


### PR DESCRIPTION
The port number in the docstring is incorrect after the examples were updated.