### PR TITLE
refactor: change get_decoder to raise ValueError for unknown formats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,5 +88,5 @@ skip-magic-trailing-comma = false
 max-complexity = 12
 
 [tool.mypy]
-python_version = 3.10
+python_version = "3.10"
 ignore_missing_imports = true

--- a/ruuvitag_sensor/decoder.py
+++ b/ruuvitag_sensor/decoder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import logging
 import math
@@ -16,30 +18,42 @@ from ruuvitag_sensor.ruuvi_types import (
 log = logging.getLogger(__name__)
 
 
-def get_decoder(data_type: int):
+def get_decoder(data_format: int) -> UrlDecoder | Df3Decoder | Df5Decoder | Df6Decoder:
     """
-    Get correct decoder for Data Type.
+    Get correct decoder for Data Format.
+
+    Args:
+        data_format: The data format number (2, 3, 4, 5, or 6)
 
     Returns:
-        object: Data decoder
+        object: Data decoder instance
+
+    Raises:
+        ValueError: If data_format is not a recognized format
     """
-    if data_type == 2:
+    if data_format == 2:
         log.warning("DATA TYPE 2 IS OBSOLETE. UPDATE YOUR TAG")
         # https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_04.md
         return UrlDecoder()
-    if data_type == 4:
+    if data_format == 4:
         log.warning("DATA TYPE 4 IS OBSOLETE. UPDATE YOUR TAG")
         # https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_04.md
         return UrlDecoder()
-    if data_type == 3:
+    if data_format == 3:
         log.warning("DATA TYPE 3 IS DEPRECATED - UPDATE YOUR TAG")
         # https://github.com/ruuvi/ruuvi-sensor-protocols/blob/master/dataformat_03.md
         return Df3Decoder()
-    if data_type == 6:
+    if data_format == 5:
+        # https://docs.ruuvi.com/communication/bluetooth-advertisements/data-format-5-rawv2
+        return Df5Decoder()
+    if data_format == 6:
         # https://docs.ruuvi.com/communication/bluetooth-advertisements/data-format-6
         return Df6Decoder()
-    # https://docs.ruuvi.com/communication/bluetooth-advertisements/data-format-5-rawv2
-    return Df5Decoder()
+
+    # This should never happen in normal operation since DataFormats.convert_data()
+    # already validates and identifies the data format. If we reach here, it indicates
+    # a programming error (e.g., convert_data was bypassed or returned an unhandled format).
+    raise ValueError(f"Unknown data format: {data_format}")
 
 
 def parse_mac(data_format: int, payload_mac: str) -> str:

--- a/ruuvitag_sensor/ruuvi.py
+++ b/ruuvitag_sensor/ruuvi.py
@@ -340,8 +340,8 @@ class RuuviTagSensor:
         mac_to_send = (
             mac
             if mac
-            else parse_mac(data_format, decoded["mac"])
-            if "mac" in decoded and decoded["mac"] is not None
+            else parse_mac(data_format, decoded["mac"])  # type: ignore[typeddict-item]
+            if "mac" in decoded and decoded["mac"] is not None  # type: ignore[typeddict-item]
             else ""
         )
 

--- a/ruuvitag_sensor/ruuvitag.py
+++ b/ruuvitag_sensor/ruuvitag.py
@@ -41,7 +41,7 @@ class RuuviTagBase:
         if self._data is None:
             self._state = {}
         elif data_format is not None:
-            self._state = get_decoder(data_format).decode_data(self._data)
+            self._state = get_decoder(data_format).decode_data(self._data)  # type: ignore[assignment]
 
         return self._state
 

--- a/tests/test_decoder.py
+++ b/tests/test_decoder.py
@@ -18,6 +18,14 @@ class TestDecoder(TestCase):
         self.assertIsInstance(dec, UrlDecoder)
         dec = get_decoder(3)
         self.assertIsInstance(dec, Df3Decoder)
+        dec = get_decoder(5)
+        self.assertIsInstance(dec, Df5Decoder)
+        dec = get_decoder(6)
+        self.assertIsInstance(dec, Df6Decoder)
+        # Test unknown format raises ValueError
+        with self.assertRaises(ValueError) as context:
+            get_decoder(99)
+        self.assertIn("Unknown data format: 99", str(context.exception))
 
     def test_decode_is_valid(self):
         decoder = UrlDecoder()


### PR DESCRIPTION
Do not use data format 5 as default in get_decoder and raise error if correct data format is not found. Not a huge issue as data format is parsed from payload, so we shouldn't have unsupported data formats at this point.