### PR TITLE
refactor: remove obsolete comment from an example

### DIFF
--- a/examples/get_async_bleak.py
+++ b/examples/get_async_bleak.py
@@ -15,6 +15,4 @@ async def main():
 
 
 if __name__ == "__main__":
-    # Note: Python 3.10 or later is required with asyncio.run
-    # For older versions of Python, use asyncio.get_event_loop().run_until_complete(main())
     asyncio.run(main())


### PR DESCRIPTION
This comment is obsolete after dropping Python 3.9 support.

I forgot to remove it in conjunction with the work on https://github.com/ttu/ruuvitag-sensor/issues/273 but better late than never (I guess?).