### PR TITLE
fix: update Bleak to version 3.0 and remove deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ keywords = ["RuuviTag", "BLE", "Bluetooth", "IoT", "Sensor"]
 dependencies = [
     "reactivex",
     "ptyprocess;platform_system=='Linux'",
-    "bleak",
+    "bleak>=3.0.0",
 ]
 
 [project.optional-dependencies]

--- a/ruuvitag_sensor/adapters/bleak_ble.py
+++ b/ruuvitag_sensor/adapters/bleak_ble.py
@@ -34,7 +34,7 @@ def _get_scanner(detection_callback: AdvertisementDataCallback, bt_device: str =
         return BleakScanner(
             detection_callback=detection_callback,
             scanning_mode=scanning_mode,  # type: ignore[arg-type]
-            adapter=bt_device,
+            bluez={"adapter": bt_device},
         )
 
     return BleakScanner(detection_callback=detection_callback, scanning_mode=scanning_mode)  # type: ignore[arg-type]


### PR DESCRIPTION
Also force installation of Bleak version 3.0 or newer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bleak dependency to require version 3.0.0 or later, ensuring compatibility with the latest Bluetooth library versions.
  * Adjusted Bluetooth adapter configuration for Linux systems to align with current library standards and improve platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->